### PR TITLE
fix: Create .sourcery.yaml

### DIFF
--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,0 +1,2 @@
+ignore_branches:
+  - "dependabot/**"


### PR DESCRIPTION
Add dependabot exclusion for sourcery

## Summary by Sourcery

Chores:
- Add Sourcery configuration to exclude dependabot branches from analysis