### PR TITLE
fix: disables autofix for PRs in pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,9 @@ default_install_hook_types: [pre-commit, commit-msg]
 default_language_version:
   python: python3
 
+ci:
+  autofix_prs: false # Disable autofix for PRs
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v5.0.0"


### PR DESCRIPTION
### Description
This PR disables autofixing of PRs by pre-commit.ci.

### Thoughts
 I am a bit conflicted on whether this is a good idea as the bot created PRs will be merged to main without passing through pre-commit and the next developer who creates a PR will have to include the fixes for the files the bot edited/created. I also think there is more to be gained by running pre-commit at the point of entry ensuring all merges to main have passed through pre-commit at least once.

## Summary by Sourcery

Chores:
- Configured pre-commit to disable autofix for pull requests