### PR TITLE
fix: Add bandit category

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -53,6 +53,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif
+          category: bandit-security-scan
         continue-on-error: true
 
       - name: Upload SARIF as artifact


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Include `category: bandit-security-scan` in the CodeQL SARIF upload step