### PR TITLE
Add ISO-8601 schedule parsing to PrometheusScheduler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "aif360",
     "hypothesis>=6.136.2",
     "pytest>=8.4.1",
+    "isodate>=0.7.2",
 ]
 
 [project.optional-dependencies]

--- a/src/service/prometheus/prometheus_scheduler.py
+++ b/src/service/prometheus/prometheus_scheduler.py
@@ -40,7 +40,7 @@ class PrometheusScheduler:
         try:
             duration = isodate.parse_duration(schedule_str)
             return int(duration.total_seconds())
-        except (isodate.ISO8601Error, AttributeError):
+        except (isodate.ISO8601Error, AttributeError, ValueError):
             # Fall back to simple format (30s, 5m, 2h) for backward compatibility
             try:
                 if schedule_str.endswith("s"):

--- a/tests/service/prometheus/test_prometheus_scheduler.py
+++ b/tests/service/prometheus/test_prometheus_scheduler.py
@@ -121,6 +121,13 @@ class TestPrometheusScheduler:
         assert PrometheusScheduler._parse_schedule_interval("P1DT2H30M45S") == 95445
         # 1 hour and 30 minutes = 5400 seconds
         assert PrometheusScheduler._parse_schedule_interval("PT1H30M") == 5400
+    
+    def test_parse_interval_iso8601_fractional(self) -> None:
+        """Test parsing ISO-8601 duration with fractional values."""
+        assert PrometheusScheduler._parse_schedule_interval("PT0.5H") == 1800
+        assert PrometheusScheduler._parse_schedule_interval("PT0.25M") == 15
+        assert PrometheusScheduler._parse_schedule_interval("PT1.5S") == 1
+
 
     def test_parse_interval_simple_format_seconds(self) -> None:
         """Test parsing simple format with seconds (backward compatibility)."""


### PR DESCRIPTION
- Introduced a new method to parse schedule intervals in ISO-8601 format.
- Updated get_service_config to utilize the new parsing method.
- Added tests for various ISO-8601 and simple format cases, including error handling for invalid formats.
- Included `isodate` as a new dependency in pyproject.toml.

Closes #39

## Summary by Sourcery

Implement unified schedule parsing in PrometheusScheduler by supporting ISO-8601 durations and existing simple formats, integrate it into service configuration with error handling and default fallback

New Features:
- Add _parse_schedule_interval to parse ISO-8601 and simple suffix-based schedule strings into seconds
- Update get_service_config to use the new parsing method and fall back to default with a warning on invalid formats

Build:
- Include isodate dependency for ISO-8601 duration parsing

Tests:
- Add tests covering ISO-8601 durations, simple suffix formats, invalid inputs, empty string, and service config integration