### PR TITLE
fix: update trivy-action to version 0.35.0

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -145,7 +145,7 @@ jobs:
                   uri: https://api.github.com/repos/trustyai-explainability/trustyai-service-operator-ci/tarball/service-python-${{ env.TAG }}
             ```
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'image'
           image-ref: "${{ env.IMAGE_NAME }}:${{ env.TAG }}"


### PR DESCRIPTION
## Summary
- Updates `aquasecurity/trivy-action` from `0.28.0` to `0.35.0`
- Fixes CI build failures caused by non-existent version reference

## Problem
The current workflow references `aquasecurity/trivy-action@0.28.0`, but this version does not exist in the repository. The correct tag format is `v0.28.0` (with `v` prefix), but the latest release is `0.35.0` (without `v` prefix).

## Solution
Updated to the latest stable release `0.35.0` (published March 7, 2026) to fix the "Unable to resolve action" error in CI builds.

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Confirm CI builds complete successfully on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Bump aquasecurity/trivy-action in the build-and-push workflow from version 0.28.0 to 0.35.0 to resolve the invalid version reference.