### PR TITLE
Update Trivy action to version 0.35.0

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -145,7 +145,7 @@ jobs:
                   uri: https://api.github.com/repos/trustyai-explainability/trustyai-service-operator-ci/tarball/service-python-${{ env.TAG }}
             ```
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'image'
           image-ref: "${{ env.IMAGE_NAME }}:${{ env.TAG }}"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Bump the Trivy security scan GitHub Action in the build-and-push workflow from v0.28.0 to v0.35.0 by pinning to the corresponding commit SHA.