### PR TITLE
refactor(prometheus): migrate gauge() to GaugeConfig API

### DIFF
--- a/src/service/prometheus/gauge_config.py
+++ b/src/service/prometheus/gauge_config.py
@@ -1,0 +1,48 @@
+"""Configuration objects for Prometheus gauge publishing."""
+
+import uuid
+
+from pydantic import BaseModel, model_validator
+
+from src.service.payloads.metrics.base_metric_request import BaseMetricRequest
+
+
+class GaugeConfig(BaseModel):
+    """Configuration for publishing a Prometheus gauge metric.
+
+    Supports three usage patterns:
+    1. Single value with request object
+    2. Named values (dict) with request object
+    3. Simple value without request (requires metric_name)
+    """
+
+    model_name: str
+    request_id: uuid.UUID
+    request: BaseMetricRequest | None = None
+    value: float | None = None
+    named_values: dict[str, float] | None = None
+    metric_name: str | None = None
+
+    @model_validator(mode="after")
+    def validate_gauge_parameters(self) -> "GaugeConfig":
+        """Validate that the gauge configuration is valid.
+
+        Rules:
+        1. If request is provided: must have either value or named_values
+        2. If request is None: must have both metric_name and value
+        """
+        if self.request is not None:
+            # Request-based gauge: must have value or named_values
+            if self.value is None and self.named_values is None:
+                msg = "Either 'value' or 'named_values' must be provided"
+                raise ValueError(msg)
+        else:
+            # Simple gauge: must have both metric_name and value
+            if self.metric_name is None:
+                msg = "Either 'request' or 'metric_name' must be provided"
+                raise ValueError(msg)
+            if self.value is None:
+                msg = "Value must be provided when using metric_name"
+                raise ValueError(msg)
+
+        return self

--- a/src/service/prometheus/gauge_config.py
+++ b/src/service/prometheus/gauge_config.py
@@ -32,9 +32,12 @@ class GaugeConfig(BaseModel):
         2. If request is None: must have both metric_name and value
         """
         if self.request is not None:
-            # Request-based gauge: must have value or named_values
+            # Request-based gauge: must have exactly one of value or named_values
             if self.value is None and self.named_values is None:
                 msg = "Either 'value' or 'named_values' must be provided"
+                raise ValueError(msg)
+            if self.value is not None and self.named_values is not None:
+                msg = "Cannot provide both 'value' and 'named_values'"
                 raise ValueError(msg)
         else:
             # Simple gauge: must have both metric_name and value

--- a/src/service/prometheus/prometheus_publisher.py
+++ b/src/service/prometheus/prometheus_publisher.py
@@ -3,11 +3,12 @@ import logging
 import re
 import threading
 import uuid
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from prometheus_client import CollectorRegistry, Gauge, REGISTRY
 from src.service.constants import PROMETHEUS_METRIC_PREFIX
 from src.service.payloads.metrics.base_metric_request import BaseMetricRequest
+from src.service.prometheus.gauge_config import GaugeConfig
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -28,6 +29,9 @@ class PrometheusPublisher:
         # public methods to retrieve them with name.
         self._gauges: Dict[str, Gauge] = {}
         self._gauges_lock: threading.RLock = threading.RLock()
+        # Track derived UUIDs created for named_values, keyed by root request ID.
+        # Protected by _values_lock.
+        self._derived_ids: Dict[uuid.UUID, List[uuid.UUID]] = {}
 
     def _get_value(self, id: uuid.UUID) -> float:
         with self._values_lock:
@@ -85,7 +89,12 @@ class PrometheusPublisher:
                 for to_remove in gauges_to_remove:
                     gauge.remove(*to_remove)
 
+        # Clean up the root value and any derived values from named_values
         self._remove_value(id)
+        with self._values_lock:
+            for derived_id in self._derived_ids.pop(id, []):
+                if derived_id in self.values:
+                    del self.values[derived_id]
 
     def _generate_tags(
         self,
@@ -104,57 +113,50 @@ class PrometheusPublisher:
         tags["request"] = str(id)
         return tags
 
-    def gauge(
-        self,
-        model_name: str,
-        id: uuid.UUID,
-        request: Optional[BaseMetricRequest] = None,
-        value: Optional[float] = None,
-        named_values: Optional[Dict[str, float]] = None,
-        metric_name: Optional[str] = None,
-    ) -> None:
-        """
-        Register a gauge metric with multiple possible parameter combinations:
-        - gauge(model_name, id, request, value)
-        - gauge(model_name, id, request, named_values)
-        - gauge(model_name, id, value, metric_name)
-        """
-        if request is not None:
-            full_metric_name = self._get_full_metric_name(request.metric_name)
+    def gauge(self, config: GaugeConfig) -> None:
+        """Register a gauge metric from a validated GaugeConfig."""
+        if config.request is not None:
+            full_metric_name = self._get_full_metric_name(config.request.metric_name)
 
-            if value is not None:
-                # gauge(model_name, id, request, value)
-                self._set_value(id, value)
-                tags = self._generate_tags(model_name=model_name, id=id, request=request)
-                self._create_or_update_gauge(name=full_metric_name, tags=tags, id=id)
-                logger.debug(f"Scheduled request for {request.metric_name} id={id}, value={value}")
+            if config.value is not None:
+                self._set_value(config.request_id, config.value)
+                tags = self._generate_tags(model_name=config.model_name, id=config.request_id, request=config.request)
+                self._create_or_update_gauge(name=full_metric_name, tags=tags, id=config.request_id)
+                logger.debug(
+                    f"Scheduled request for {config.request.metric_name} id={config.request_id}, value={config.value}"
+                )
 
-            elif named_values is not None:
-                # gauge(model_name, id, request, named_values)
-                for idx, (key, val) in enumerate(named_values.items()):
-                    concat_string = f"{str(id)}{idx}"
+            elif config.named_values is not None:
+                derived_ids: List[uuid.UUID] = []
+                for idx, (key, val) in enumerate(config.named_values.items()):
+                    concat_string = f"{str(config.request_id)}{idx}"
                     new_id = self.generate_uuid(concat_string)
+                    derived_ids.append(new_id)
                     self._set_value(new_id, val)
 
-                    tags = self._generate_tags(model_name=model_name, id=id, request=request)
+                    tags = self._generate_tags(
+                        model_name=config.model_name, id=config.request_id, request=config.request
+                    )
                     tags["subcategory"] = key
                     self._create_or_update_gauge(name=full_metric_name, tags=tags, id=new_id)
-                logger.debug(f"Scheduled request for {request.metric_name} id={id}, value={named_values}")
-            else:
-                raise ValueError("Either 'value' or 'named_values' must be provided")
 
-        elif metric_name is not None and value is not None:
-            # gauge(model_name, id, value, metric_name)
-            full_metric_name = self._get_full_metric_name(metric_name)
-            self._set_value(id, value)
+                # Track derived IDs so remove_gauge can clean them up
+                with self._values_lock:
+                    self._derived_ids[config.request_id] = derived_ids
 
-            tags = self._generate_tags(model_name=model_name, id=id)
-            self._create_or_update_gauge(name=full_metric_name, tags=tags, id=id)
-
-            logger.debug(f"Scheduled request for {metric_name} id={id}, value={value}")
+                logger.debug(
+                    f"Scheduled request for {config.request.metric_name} id={config.request_id}, value={config.named_values}"
+                )
 
         else:
-            raise ValueError("Either 'request' or 'metric_name' & 'value' must be provided")
+            # Simple gauge without request (metric_name required, validated by GaugeConfig)
+            full_metric_name = self._get_full_metric_name(config.metric_name)
+            self._set_value(config.request_id, config.value)
+
+            tags = self._generate_tags(model_name=config.model_name, id=config.request_id)
+            self._create_or_update_gauge(name=full_metric_name, tags=tags, id=config.request_id)
+
+            logger.debug(f"Scheduled request for {config.metric_name} id={config.request_id}, value={config.value}")
 
     def _get_full_metric_name(self, metric_name: str) -> str:
         if not PROMETHEUS_METRIC_PREFIX.strip():

--- a/src/service/prometheus/prometheus_publisher.py
+++ b/src/service/prometheus/prometheus_publisher.py
@@ -3,9 +3,9 @@ import logging
 import re
 import threading
 import uuid
-from typing import Dict, List, Optional
 
-from prometheus_client import CollectorRegistry, Gauge, REGISTRY
+from prometheus_client import REGISTRY, CollectorRegistry, Gauge
+
 from src.service.constants import PROMETHEUS_METRIC_PREFIX
 from src.service.payloads.metrics.base_metric_request import BaseMetricRequest
 from src.service.prometheus.gauge_config import GaugeConfig
@@ -22,16 +22,16 @@ PROMETHEUS_METRIC_NAME_REGEX = re.compile(r"^[a-z_:][a-z0-9_:]*$")
 class PrometheusPublisher:
     def __init__(self, registry: CollectorRegistry = REGISTRY) -> None:
         self.registry: CollectorRegistry = registry
-        self.values: Dict[uuid.UUID, float] = {}
+        self.values: dict[uuid.UUID, float] = {}
         self._values_lock: threading.RLock = threading.RLock()
         # Track gauges by metric name to avoid re-creating them
         # This is because prometheus_client doesn't expose
         # public methods to retrieve them with name.
-        self._gauges: Dict[str, Gauge] = {}
+        self._gauges: dict[str, Gauge] = {}
         self._gauges_lock: threading.RLock = threading.RLock()
         # Track derived UUIDs created for named_values, keyed by root request ID.
         # Protected by _values_lock.
-        self._derived_ids: Dict[uuid.UUID, List[uuid.UUID]] = {}
+        self._derived_ids: dict[uuid.UUID, list[uuid.UUID]] = {}
 
     def _get_value(self, id: uuid.UUID) -> float:
         with self._values_lock:
@@ -46,7 +46,7 @@ class PrometheusPublisher:
             if id in self.values:
                 del self.values[id]
 
-    def _create_or_update_gauge(self, name: str, tags: Dict[str, str], id: uuid.UUID) -> None:
+    def _create_or_update_gauge(self, name: str, tags: dict[str, str], id: uuid.UUID) -> None:
         with self._gauges_lock:
             # We need to track gauges because prometheus_client doesn't provide
             # a way to retrieve an existing gauge by name from the registry
@@ -81,7 +81,7 @@ class PrometheusPublisher:
                 # based on the "request" label matching the provided ID.
                 # If prometheus_client adds public APIs for this in the future,
                 # this should be refactored to use those instead.
-                for labels, _ in gauge._metrics.items():
+                for labels in gauge._metrics:
                     labels_dict = dict(zip(gauge._labelnames, labels))
                     if labels_dict.get("request") == str(id):
                         gauges_to_remove.append(labels)
@@ -100,9 +100,9 @@ class PrometheusPublisher:
         self,
         model_name: str,
         id: uuid.UUID,
-        request: Optional[BaseMetricRequest] = None,
-    ) -> Dict[str, str]:
-        tags: Dict[str, str] = {}
+        request: BaseMetricRequest | None = None,
+    ) -> dict[str, str]:
+        tags: dict[str, str] = {}
 
         if request is not None:
             tags.update(request.retrieve_default_tags())
@@ -127,9 +127,9 @@ class PrometheusPublisher:
                 )
 
             elif config.named_values is not None:
-                derived_ids: List[uuid.UUID] = []
+                derived_ids: list[uuid.UUID] = []
                 for idx, (key, val) in enumerate(config.named_values.items()):
-                    concat_string = f"{str(config.request_id)}{idx}"
+                    concat_string = f"{config.request_id!s}{idx}"
                     new_id = self.generate_uuid(concat_string)
                     derived_ids.append(new_id)
                     self._set_value(new_id, val)
@@ -153,7 +153,10 @@ class PrometheusPublisher:
                 )
 
         else:
-            # Simple gauge without request (metric_name required, validated by GaugeConfig)
+            # Simple gauge without request — metric_name and value guaranteed
+            # non-None by GaugeConfig.validate_gauge_parameters()
+            assert config.metric_name is not None
+            assert config.value is not None
             full_metric_name = self._get_full_metric_name(config.metric_name)
             self._set_value(config.request_id, config.value)
 

--- a/src/service/prometheus/prometheus_publisher.py
+++ b/src/service/prometheus/prometheus_publisher.py
@@ -140,8 +140,12 @@ class PrometheusPublisher:
                     tags["subcategory"] = key
                     self._create_or_update_gauge(name=full_metric_name, tags=tags, id=new_id)
 
-                # Track derived IDs so remove_gauge can clean them up
+                # Clean up old derived values (from previous calculation cycle)
+                # before tracking the new ones
                 with self._values_lock:
+                    for old_id in self._derived_ids.pop(config.request_id, []):
+                        if old_id in self.values:
+                            del self.values[old_id]
                     self._derived_ids[config.request_id] = derived_ids
 
                 logger.debug(

--- a/src/service/prometheus/prometheus_scheduler.py
+++ b/src/service/prometheus/prometheus_scheduler.py
@@ -15,6 +15,7 @@ from src.service.data.exceptions import DataframeCreateException, StorageReadExc
 from src.service.data.storage.pvc import MissingH5PYDataException
 from src.service.payloads.metrics.base_metric_request import BaseMetricRequest
 from src.service.payloads.metrics.request_reconciler import RequestReconciler
+from src.service.prometheus.gauge_config import GaugeConfig
 from src.service.prometheus.metric_value_carrier import MetricValueCarrier
 from src.service.prometheus.prometheus_publisher import PrometheusPublisher
 
@@ -210,10 +211,12 @@ class PrometheusScheduler:
         """
         try:
             self.publisher.gauge(
-                model_name="",
-                id=PrometheusPublisher.generate_uuid("model_count"),
-                metric_name="MODEL_COUNT_TOTAL",
-                value=len(verified_models),
+                GaugeConfig(
+                    model_name="",
+                    request_id=PrometheusPublisher.generate_uuid("model_count"),
+                    metric_name="MODEL_COUNT_TOTAL",
+                    value=len(verified_models),
+                )
             )
         except ValueError as e:
             self._handle_error(
@@ -313,10 +316,12 @@ class PrometheusScheduler:
 
         try:
             self.publisher.gauge(
-                model_name=model_id,
-                id=PrometheusPublisher.generate_uuid(model_id),
-                metric_name="MODEL_OBSERVATIONS_TOTAL",
-                value=total_observations,
+                GaugeConfig(
+                    model_name=model_id,
+                    request_id=PrometheusPublisher.generate_uuid(model_id),
+                    metric_name="MODEL_OBSERVATIONS_TOTAL",
+                    value=total_observations,
+                )
             )
         except ValueError as e:
             self._handle_error(
@@ -552,17 +557,21 @@ class PrometheusScheduler:
         try:
             if value.is_single():
                 self.publisher.gauge(
-                    model_name=model_id,
-                    id=req_id,
-                    request=request,
-                    value=value.get_value(),
+                    GaugeConfig(
+                        model_name=model_id,
+                        request_id=req_id,
+                        request=request,
+                        value=value.get_value(),
+                    )
                 )
             else:
                 self.publisher.gauge(
-                    model_name=model_id,
-                    id=req_id,
-                    request=request,
-                    named_values=value.get_named_values(),
+                    GaugeConfig(
+                        model_name=model_id,
+                        request_id=req_id,
+                        request=request,
+                        named_values=value.get_named_values(),
+                    )
                 )
         except ValueError as e:
             self._handle_error(

--- a/tests/endpoints/metrics/drift/factory.py
+++ b/tests/endpoints/metrics/drift/factory.py
@@ -1032,6 +1032,7 @@ def make_retrieve_default_tags_called_directly_by_prometheus_publisher_test(
 
         from prometheus_client import CollectorRegistry
 
+        from src.service.prometheus.gauge_config import GaugeConfig
         from src.service.prometheus.prometheus_publisher import PrometheusPublisher
 
         # Create request without metric_name (it defaults to None, but model_validator sets it)
@@ -1057,7 +1058,7 @@ def make_retrieve_default_tags_called_directly_by_prometheus_publisher_test(
         test_id = uuid.uuid4()
 
         # This should not raise an error
-        publisher.gauge(model_name="test_model", id=test_id, value=0.5, request=request)
+        publisher.gauge(GaugeConfig(model_name="test_model", request_id=test_id, value=0.5, request=request))
 
         # Verify the gauge was created successfully
         metric_name = f"trustyai_{request.metric_name.lower()}"

--- a/tests/service/prometheus/test_prometheus_publisher.py
+++ b/tests/service/prometheus/test_prometheus_publisher.py
@@ -170,6 +170,38 @@ class TestPrometheusPublisher:
         publisher.remove_gauge(name=mock_request.metric_name, id=test_id)
         assert test_id not in publisher.values
 
+    def test_remove_gauge_cleans_up_named_values(
+        self, publisher: PrometheusPublisher, mock_request: MockMetricRequest
+    ):
+        """Test that remove_gauge cleans up derived IDs created from named_values."""
+        test_id = uuid.uuid4()
+        named_values = {"feature1": 0.3, "feature2": 0.7}
+
+        # Create gauge with named_values
+        publisher.gauge(GaugeConfig(
+            model_name="test_model",
+            request_id=test_id,
+            named_values=named_values,
+            request=mock_request,
+        ))
+
+        # Verify derived IDs are tracked
+        assert test_id in publisher._derived_ids
+        derived_ids = publisher._derived_ids[test_id]
+        assert len(derived_ids) == 2
+
+        # Verify derived values exist
+        for did in derived_ids:
+            assert did in publisher.values
+
+        # Remove gauge — should clean up all derived values
+        publisher.remove_gauge(name=mock_request.metric_name, id=test_id)
+
+        # Verify root and derived values are all gone
+        assert test_id not in publisher._derived_ids
+        for did in derived_ids:
+            assert did not in publisher.values
+
     def test_duplicate_gauge_creation(self, publisher: PrometheusPublisher, mock_request: MockMetricRequest):
         """Test that creating gauges with same name but different labels."""
         test_id1 = uuid.uuid4()

--- a/tests/service/prometheus/test_prometheus_publisher.py
+++ b/tests/service/prometheus/test_prometheus_publisher.py
@@ -1,13 +1,11 @@
 import threading
 import uuid
-from typing import Dict
 
 import pytest
-
 from prometheus_client import CollectorRegistry, Gauge
+
 from src.service.constants import PROMETHEUS_METRIC_PREFIX
 from src.service.payloads.metrics.base_metric_request import BaseMetricRequest
-
 from src.service.prometheus.gauge_config import GaugeConfig
 from src.service.prometheus.prometheus_publisher import PrometheusPublisher
 
@@ -23,7 +21,7 @@ class MockMetricRequest(BaseMetricRequest):
             batch_size=100,
         )
 
-    def retrieve_tags(self) -> Dict[str, str]:
+    def retrieve_tags(self) -> dict[str, str]:
         return {"custom_tag": "custom_value"}
 
 
@@ -151,7 +149,7 @@ class TestPrometheusPublisher:
             thread.join()
 
         # Verify all values were stored correctly
-        for thread_id, (test_id, test_value) in test_values.items():
+        for test_id, test_value in test_values.values():
             assert test_id in publisher.values
             assert publisher.values[test_id] == test_value
 
@@ -170,20 +168,20 @@ class TestPrometheusPublisher:
         publisher.remove_gauge(name=mock_request.metric_name, id=test_id)
         assert test_id not in publisher.values
 
-    def test_remove_gauge_cleans_up_named_values(
-        self, publisher: PrometheusPublisher, mock_request: MockMetricRequest
-    ):
+    def test_remove_gauge_cleans_up_named_values(self, publisher: PrometheusPublisher, mock_request: MockMetricRequest):
         """Test that remove_gauge cleans up derived IDs created from named_values."""
         test_id = uuid.uuid4()
         named_values = {"feature1": 0.3, "feature2": 0.7}
 
         # Create gauge with named_values
-        publisher.gauge(GaugeConfig(
-            model_name="test_model",
-            request_id=test_id,
-            named_values=named_values,
-            request=mock_request,
-        ))
+        publisher.gauge(
+            GaugeConfig(
+                model_name="test_model",
+                request_id=test_id,
+                named_values=named_values,
+                request=mock_request,
+            )
+        )
 
         # Verify derived IDs are tracked
         assert test_id in publisher._derived_ids

--- a/tests/service/prometheus/test_prometheus_publisher.py
+++ b/tests/service/prometheus/test_prometheus_publisher.py
@@ -8,6 +8,7 @@ from prometheus_client import CollectorRegistry, Gauge
 from src.service.constants import PROMETHEUS_METRIC_PREFIX
 from src.service.payloads.metrics.base_metric_request import BaseMetricRequest
 
+from src.service.prometheus.gauge_config import GaugeConfig
 from src.service.prometheus.prometheus_publisher import PrometheusPublisher
 
 
@@ -47,7 +48,9 @@ class TestPrometheusPublisher:
         test_id = uuid.uuid4()
         test_value = 0.5
 
-        publisher.gauge(model_name="test_model", id=test_id, value=test_value, request=mock_request)
+        publisher.gauge(
+            GaugeConfig(model_name="test_model", request_id=test_id, value=test_value, request=mock_request)
+        )
 
         # Verify value is stored
         assert test_id in publisher.values
@@ -73,10 +76,12 @@ class TestPrometheusPublisher:
         test_named_values = {"feature1": 0.3, "feature2": 0.7}
 
         publisher.gauge(
-            model_name="test_model",
-            id=test_id,
-            named_values=test_named_values,
-            request=mock_request,
+            GaugeConfig(
+                model_name="test_model",
+                request_id=test_id,
+                named_values=test_named_values,
+                request=mock_request,
+            )
         )
 
         # Verify multiple values are stored (one for each named value)
@@ -101,10 +106,12 @@ class TestPrometheusPublisher:
         test_value = 1.0
 
         publisher.gauge(
-            model_name="test_model",
-            id=test_id,
-            value=test_value,
-            metric_name="simple_metric",
+            GaugeConfig(
+                model_name="test_model",
+                request_id=test_id,
+                value=test_value,
+                metric_name="simple_metric",
+            )
         )
 
         # Verify value is stored
@@ -125,10 +132,12 @@ class TestPrometheusPublisher:
             test_value = thread_id * 0.1
             test_values[thread_id] = (test_id, test_value)
             publisher.gauge(
-                model_name=f"model_{thread_id}",
-                id=test_id,
-                value=test_value,
-                request=mock_request,
+                GaugeConfig(
+                    model_name=f"model_{thread_id}",
+                    request_id=test_id,
+                    value=test_value,
+                    request=mock_request,
+                )
             )
 
         # Create multiple threads
@@ -152,7 +161,9 @@ class TestPrometheusPublisher:
         test_value = 0.5
 
         # Create gauge
-        publisher.gauge(model_name="test_model", id=test_id, value=test_value, request=mock_request)
+        publisher.gauge(
+            GaugeConfig(model_name="test_model", request_id=test_id, value=test_value, request=mock_request)
+        )
         assert test_id in publisher.values
 
         # Remove gauge
@@ -165,10 +176,10 @@ class TestPrometheusPublisher:
         test_id2 = uuid.uuid4()
 
         # Create first gauge
-        publisher.gauge(model_name="test_model", id=test_id1, value=0.5, request=mock_request)
+        publisher.gauge(GaugeConfig(model_name="test_model", request_id=test_id1, value=0.5, request=mock_request))
 
         # Create second gauge with same metric name - should work with same labels
-        publisher.gauge(model_name="test_model", id=test_id2, value=0.7, request=mock_request)
+        publisher.gauge(GaugeConfig(model_name="test_model", request_id=test_id2, value=0.7, request=mock_request))
 
         # Both values should be stored
         assert test_id1 in publisher.values
@@ -206,14 +217,11 @@ class TestPrometheusPublisher:
 
         # Test missing both value and named_values
         with pytest.raises(ValueError, match="Either 'value' or 'named_values' must be provided"):
-            publisher.gauge(model_name="test_model", id=test_id, request=mock_request)
+            GaugeConfig(model_name="test_model", request_id=test_id, request=mock_request)
 
         # Test missing both request and metric_name
-        with pytest.raises(
-            ValueError,
-            match="Either 'request' or 'metric_name' & 'value' must be provided",
-        ):
-            publisher.gauge(model_name="test_model", id=test_id, value=0.5)
+        with pytest.raises(ValueError, match="Either 'request' or 'metric_name' must be provided"):
+            GaugeConfig(model_name="test_model", request_id=test_id, value=0.5)
 
     def test_valid_metric_names(self, publisher: PrometheusPublisher):
         """Test validation of valid Prometheus metric names."""
@@ -263,8 +271,10 @@ class TestPrometheusPublisher:
 
         with pytest.raises(ValueError, match="Invalid Prometheus metric name"):
             publisher.gauge(
-                model_name="test_model",
-                id=test_id,
-                value=test_value,
-                request=mock_request,
+                GaugeConfig(
+                    model_name="test_model",
+                    request_id=test_id,
+                    value=test_value,
+                    request=mock_request,
+                )
             )


### PR DESCRIPTION
## Summary

- Replace the 6-parameter `gauge()` signature with a validated `GaugeConfig` Pydantic model
- Fix named-value cleanup leak: derived UUIDs from `named_values` are now tracked and cleaned up in `remove_gauge()`
- All callers migrated atomically (publisher, scheduler, tests, drift factory)

**Jira:** RHOAIENG-57849

### Changes

**New: `gauge_config.py`** — Pydantic model with three usage patterns:
1. Single value with request object
2. Named values (dict) with request object
3. Simple value without request (requires metric_name)

Validation at construction time catches invalid combinations early.

**`prometheus_publisher.py`:**
- `gauge()` accepts `GaugeConfig` instead of 6 keyword args
- New `_derived_ids` dict tracks derived UUIDs created for `named_values`
- `remove_gauge()` now cleans up both root and derived values (fixes leak)

**`prometheus_scheduler.py`:**
- All 4 `publisher.gauge(...)` call sites migrated to `publisher.gauge(GaugeConfig(...))`

**Tests:**
- `test_prometheus_publisher.py`: all calls updated, `test_invalid_gauge_parameters` now tests GaugeConfig validation
- `test_remove_gauge_cleans_up_named_values`: new test covering the leak fix
- `factory.py`: prometheus publisher integration test updated

### CodeRabbit issues resolved
- #5: Named-value cleanup leak — derived UUIDs now tracked and cleaned up
- #6: gauge() callers — all migrated atomically

### Known CI status

| Check | Status | Notes |
|---|---|---|
| test (3.12) | ✅ | |
| test (3.14) | ✅ | |
| bandit-scan | ✅ | |
| build-and-push-ci | ❌ expected | Uses `pull_request_target` → runs main's workflow which references `Dockerfile` (renamed to `Containerfile`). Fix is in PR #118, takes effect on merge. Pre-existing on main. |
| pre-commit.ci | ❌ expected | Pre-existing failure on main (missing `.flake8` config). Fixed by PR #118 which replaces flake8 with ruff. |

## Test plan

- [x] `uv run pytest tests/service/prometheus/ -v` — 28 tests pass
- [x] `uv run pytest tests/endpoints/metrics/drift/ -v` — 120 tests pass
- [x] 148 total tests pass (147 original + 1 new for named_values cleanup)
- [x] `uv run ruff check` — clean on all modified files
- [x] `uv run pyrefly check` — clean on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor Prometheus gauge publishing to use a validated GaugeConfig object and ensure cleanup of all values associated with a gauge, including derived IDs from named values.

New Features:
- Introduce a GaugeConfig Pydantic model to encapsulate and validate Prometheus gauge configuration options.

Bug Fixes:
- Fix a leak where derived UUIDs created for named gauge values were not tracked or cleaned up when removing gauges.

Enhancements:
- Simplify PrometheusPublisher.gauge to accept a single configuration object instead of multiple parameters and update all callers accordingly.
- Track and manage derived gauge value IDs within PrometheusPublisher to support repeated named_values updates without stale data.
- Modernize type hints in Prometheus publisher and tests to use built-in generics syntax.

Tests:
- Update existing Prometheus publisher and scheduler tests to use GaugeConfig and add coverage for named_values cleanup and validation errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved Prometheus metrics publishing configuration and cleanup logic for more reliable metric management and removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->