### PR TITLE
refactor(drift): replace kwargs with explicit typed parameters

### DIFF
--- a/src/core/metrics/drift/compare_means.py
+++ b/src/core/metrics/drift/compare_means.py
@@ -5,13 +5,18 @@ Detects drift by comparing means between reference and current distributions
 using independent two-sample t-tests (Student's t-test or Welch's t-test).
 """
 
+from typing import Literal
+
 import numpy as np
 from scipy import stats
+
+# Type alias for validated nan_policy values
+NanPolicy = Literal["propagate", "raise", "omit"]
 
 # Default parameter values for t-test
 DEFAULT_ALPHA = 0.05  # Default significance level for t-test
 DEFAULT_EQUAL_VAR = False  # Use Welch's t-test by default (does not assume equal variances)
-DEFAULT_NAN_POLICY = "omit"  # Omit NaN values by default
+DEFAULT_NAN_POLICY: NanPolicy = "omit"  # Omit NaN values by default
 
 
 class CompareMeans:
@@ -28,7 +33,9 @@ class CompareMeans:
         reference_data: np.ndarray,
         current_data: np.ndarray,
         alpha: float = DEFAULT_ALPHA,
-        **kwargs,
+        *,
+        equal_var: bool = DEFAULT_EQUAL_VAR,
+        nan_policy: NanPolicy = DEFAULT_NAN_POLICY,
     ) -> dict[str, float | bool]:
         """
         Perform a t-test statistic and p-value for drift detection.
@@ -39,23 +46,15 @@ class CompareMeans:
         :param reference_data: Reference distribution data (baseline) - numpy array
         :param current_data: Current distribution data to compare - numpy array
         :param alpha: Significance level for hypothesis testing (default: DEFAULT_ALPHA)
-        :param kwargs: Additional keyword arguments to pass to scipy.stats.ttest_ind
-                      (e.g., equal_var=False for Welch's t-test, nan_policy='omit')
+        :param equal_var: If True, use Student's t-test (assumes equal variances).
+            If False (default), use Welch's t-test.
+        :param nan_policy: How to handle NaN values: "propagate", "raise", or "omit" (default)
         :return: Dictionary containing statistic, p_value, and drift_detected boolean
         """
         if len(reference_data) == 0 or len(current_data) == 0:
             raise ValueError("Input arrays cannot be empty")
 
-        # Set default arguments if not provided
-        if "equal_var" not in kwargs:
-            kwargs["equal_var"] = DEFAULT_EQUAL_VAR
-        if "nan_policy" not in kwargs:
-            kwargs["nan_policy"] = DEFAULT_NAN_POLICY
-
-        # Perform independent two-sample t-test
-        # scipy.stats.ttest_ind handles both regular arrays and masked arrays
-        # Masked elements are automatically ignored
-        statistic, p_value = stats.ttest_ind(reference_data, current_data, **kwargs)
+        statistic, p_value = stats.ttest_ind(reference_data, current_data, equal_var=equal_var, nan_policy=nan_policy)
 
         return {
             "statistic": float(statistic),

--- a/src/core/metrics/drift/jensen_shannon.py
+++ b/src/core/metrics/drift/jensen_shannon.py
@@ -6,12 +6,13 @@ JS divergence is a symmetric and smoothed version of the Kullback–Leibler dive
 bounded between 0 and 1 (or 0 and log(2) in nats).
 """
 
-from typing import Any, Literal
+from typing import Literal
 
 import numpy as np
 from scipy.spatial.distance import jensenshannon
 
 from . import utils
+from .utils import BwMethod
 
 # Default constants for Jensen-Shannon metric
 DEFAULT_STATISTIC: Literal["distance", "divergence"] = "distance"
@@ -40,7 +41,8 @@ class JensenShannon:
         method: Literal["kde", "hist"] = DEFAULT_METHOD,
         grid_points: int = DEFAULT_GRID_POINTS,
         bins: int = DEFAULT_BINS,
-        **kwargs: Any,
+        *,
+        bw_method: BwMethod = None,
     ) -> dict[str, float]:
         """
         Calculate Jensen-Shannon divergence between distributions using scipy.spatial.distance.jensenshannon.
@@ -58,6 +60,7 @@ class JensenShannon:
             estimation on a fixed grid and ``"hist"`` for histogram-based estimation.
         :param grid_points: Number of grid points used when ``method="kde"``.
         :param bins: Number of histogram bins used when ``method="hist"``.
+        :param bw_method: Bandwidth selection method for KDE (passed to scipy.stats.gaussian_kde).
         :return: Dictionary containing js_divergence and drift_detected
         """
         # Validate statistic parameter
@@ -66,9 +69,9 @@ class JensenShannon:
 
         # Generate probability distributions from data on a common grid
         if method == "kde":
-            p_ref, p_cur = utils.prob_dist_kde(data_ref, data_cur, grid_points, **kwargs)
+            p_ref, p_cur = utils.prob_dist_kde(data_ref, data_cur, grid_points, bw_method=bw_method)
         elif method == "hist":
-            p_ref, p_cur = utils.prob_dist_hist(data_ref, data_cur, bins, **kwargs)
+            p_ref, p_cur = utils.prob_dist_hist(data_ref, data_cur, bins)
         else:
             raise ValueError("`method` must be `hist` or `kde`.")
 

--- a/src/core/metrics/drift/utils.py
+++ b/src/core/metrics/drift/utils.py
@@ -6,7 +6,8 @@ This module provides common utility functions for computing probability distribu
 from data samples using different methods (histogram and kernel density estimation).
 """
 
-from typing import Literal
+from collections.abc import Callable
+from typing import Any, Literal
 
 import numpy as np
 from scipy.stats import gaussian_kde
@@ -15,8 +16,10 @@ from scipy.stats import gaussian_kde
 DEFAULT_BINS = 64
 DEFAULT_GRID_POINTS = 256
 
-# Type aliases for validated parameter values
-BwMethod = Literal["scott", "silverman"] | float | None
+# Type alias for gaussian_kde bandwidth selection methods.
+# Supports named methods, scalar factors, None (default), and callables
+# that receive a gaussian_kde instance and return a bandwidth factor.
+BwMethod = Literal["scott", "silverman"] | float | Callable[[Any], float] | None
 
 
 def prob_dist_hist(x: np.ndarray, y: np.ndarray, bins: int = DEFAULT_BINS) -> np.ndarray:

--- a/src/core/metrics/drift/utils.py
+++ b/src/core/metrics/drift/utils.py
@@ -6,7 +6,7 @@ This module provides common utility functions for computing probability distribu
 from data samples using different methods (histogram and kernel density estimation).
 """
 
-from typing import Any
+from typing import Literal
 
 import numpy as np
 from scipy.stats import gaussian_kde
@@ -15,8 +15,11 @@ from scipy.stats import gaussian_kde
 DEFAULT_BINS = 64
 DEFAULT_GRID_POINTS = 256
 
+# Type aliases for validated parameter values
+BwMethod = Literal["scott", "silverman"] | float | None
 
-def prob_dist_hist(x: np.ndarray, y: np.ndarray, bins: int = DEFAULT_BINS, **kwargs: Any) -> np.ndarray:
+
+def prob_dist_hist(x: np.ndarray, y: np.ndarray, bins: int = DEFAULT_BINS) -> np.ndarray:
     """
     Generate probability distributions from two datasets using histograms.
 
@@ -26,7 +29,6 @@ def prob_dist_hist(x: np.ndarray, y: np.ndarray, bins: int = DEFAULT_BINS, **kwa
     :param x: First dataset (reference distribution)
     :param y: Second dataset (current distribution)
     :param bins: Number of bins for histogram (default: 64)
-    :param kwargs: Additional keyword arguments (currently unused, for future extensibility)
     :return: List containing two normalized probability distributions [p_x, p_y]
     :raises ValueError: If either input array is empty or contains NaN values
     """
@@ -61,7 +63,13 @@ def prob_dist_hist(x: np.ndarray, y: np.ndarray, bins: int = DEFAULT_BINS, **kwa
     return [p_x, p_y]
 
 
-def prob_dist_kde(x: np.ndarray, y: np.ndarray, grid_points: int = DEFAULT_GRID_POINTS, **kwargs: Any) -> np.ndarray:
+def prob_dist_kde(
+    x: np.ndarray,
+    y: np.ndarray,
+    grid_points: int = DEFAULT_GRID_POINTS,
+    *,
+    bw_method: BwMethod = None,
+) -> np.ndarray:
     """
     Generate probability distributions from two datasets using kernel density estimation.
 
@@ -71,8 +79,7 @@ def prob_dist_kde(x: np.ndarray, y: np.ndarray, grid_points: int = DEFAULT_GRID_
     :param x: First dataset (reference distribution)
     :param y: Second dataset (current distribution)
     :param grid_points: Number of points in the evaluation grid (default: 256)
-    :param kwargs: Additional keyword arguments passed to scipy.stats.gaussian_kde
-                   (e.g., bw_method for bandwidth selection)
+    :param bw_method: Bandwidth selection method passed to scipy.stats.gaussian_kde
     :return: List containing two normalized probability distributions [p_x, p_y]
     :raises ValueError: If either input array is empty, contains NaN values, or has insufficient
                         sample size for KDE estimation
@@ -104,8 +111,8 @@ def prob_dist_kde(x: np.ndarray, y: np.ndarray, grid_points: int = DEFAULT_GRID_
     x_range = np.linspace(x_min, x_max, grid_points)
 
     # Estimate continuous distributions using kernel density estimate with Gaussian kernels
-    kde_x = gaussian_kde(x, **kwargs)
-    kde_y = gaussian_kde(y, **kwargs)
+    kde_x = gaussian_kde(x, bw_method=bw_method)
+    kde_y = gaussian_kde(y, bw_method=bw_method)
 
     # Generate probability distributions
     p_x = kde_x(x_range)

--- a/tests/core/metrics/drift/test_utils.py
+++ b/tests/core/metrics/drift/test_utils.py
@@ -189,11 +189,11 @@ class TestProbDistKDE:
         nonempty = np.array([1.0, 2.0, 3.0])
 
         with pytest.raises(ValueError, match="cannot be empty"):
-            utils.prob_dist_kde(empty, nonempty, bins=10)
+            utils.prob_dist_kde(empty, nonempty)
         with pytest.raises(ValueError, match="cannot be empty"):
-            utils.prob_dist_kde(nonempty, empty, bins=10)
+            utils.prob_dist_kde(nonempty, empty)
         with pytest.raises(ValueError, match="cannot be empty"):
-            utils.prob_dist_kde(empty, empty, bins=10)
+            utils.prob_dist_kde(empty, empty)
 
     def test_prob_dist_kde_nan_data_raises_error(self):
         """Test that NaN values in input arrays raise ValueError."""


### PR DESCRIPTION
## Summary

Replace `**kwargs: Any` with explicit, typed parameters across all drift metric functions. This eliminates the ANN401 (Any type annotation) lint violation at the root cause and provides IDE autocompletion and type safety.

**Jira:** RHOAIENG-57849

### Changes

**New type aliases:**
- `NanPolicy = Literal["propagate", "raise", "omit"]` — for scipy nan_policy
- `BwMethod = Literal["scott", "silverman"] | float | None` — for scipy KDE bandwidth

**`utils.py`:**
- `prob_dist_hist()`: removed unused `**kwargs` parameter
- `prob_dist_kde()`: replaced `**kwargs` with explicit `bw_method: BwMethod` (keyword-only)

**`compare_means.py`:**
- `ttest_ind()`: replaced `**kwargs` with explicit `equal_var: bool` and `nan_policy: NanPolicy` (keyword-only after `*`)
- Removed manual default-setting logic (`if "equal_var" not in kwargs`) — defaults now in signature

**`jensen_shannon.py`:**
- `jensenshannon()`: replaced `**kwargs` with explicit `bw_method: BwMethod` (keyword-only)
- Passes `bw_method` explicitly to `prob_dist_kde()` instead of `**kwargs`

**Test fix:**
- `test_utils.py`: removed spurious `bins=10` passed to `prob_dist_kde()` (was silently swallowed by `**kwargs`, now would be TypeError)

### Known CI status

| Check | Status | Notes |
|---|---|---|
| test (3.12) | ✅ expected | 52/52 drift tests pass locally |
| test (3.14) | ✅ expected | |
| bandit-scan | ✅ expected | |
| build-and-push-ci | ❌ expected | Pre-existing: `pull_request_target` runs main's workflow referencing `Dockerfile` (renamed to `Containerfile`). Fix in PR #118. |
| pre-commit.ci | ❌ expected | Pre-existing: missing `.flake8` config. Fixed by PR #118. |

## Test plan

- [x] `uv run pytest tests/core/metrics/drift/ -v` — 52 tests pass
- [x] `uv run ruff check` — clean on all modified files
- [x] `uv run ruff format --check` — clean on all modified files
- [x] `uv run pyrefly check` — 6 pre-existing errors (scipy/numpy type stubs), unchanged from main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace generic kwargs-based drift metric parameters with explicit, typed function arguments for improved type safety and clearer APIs.

New Features:
- Introduce NanPolicy and BwMethod type aliases to validate allowed scipy parameter values.

Enhancements:
- Make ttest_ind accept explicit equal_var and nan_policy keyword-only parameters instead of arbitrary kwargs.
- Restrict prob_dist_hist and prob_dist_kde to explicit parameters and propagate bw_method explicitly through Jensen-Shannon divergence calculations.
- Improve docstrings and defaults to reflect the new explicit parameter interfaces.

Tests:
- Adjust drift utils tests to align with the updated prob_dist_kde signature and removed unused kwargs.