### PR TITLE
refactor(data): rename InvalidSchemaException, fix async docstring, use uuid4

### DIFF
--- a/src/service/data/exceptions.py
+++ b/src/service/data/exceptions.py
@@ -1,16 +1,10 @@
 class DataframeCreateException(Exception):
     """Exception raised when a dataframe cannot be created."""
 
-    pass
-
 
 class StorageReadException(Exception):
     """Exception raised when storage cannot be read."""
 
-    pass
 
-
-class InvalidSchemaException(Exception):
+class InvalidSchemaError(Exception):
     """Exception raised when a schema is invalid."""
-
-    pass

--- a/src/service/data/metadata/storage_metadata.py
+++ b/src/service/data/metadata/storage_metadata.py
@@ -1,6 +1,4 @@
-from typing import Dict
-
-from src.service.data.exceptions import InvalidSchemaException
+from src.service.data.exceptions import InvalidSchemaError
 from src.service.payloads.service.schema import Schema
 
 
@@ -72,14 +70,14 @@ class StorageMetadata:
     def merge_input_schema(self, other_schema: Schema) -> None:
         """Merge another schema with the input schema."""
         if other_schema != self.input_schema:
-            raise InvalidSchemaException("Original schema and schema-to-merge are not compatible")
+            raise InvalidSchemaError("Original schema and schema-to-merge are not compatible")
 
     def merge_output_schema(self, other_schema: Schema) -> None:
         """Merge another schema with the output schema."""
         if other_schema != self.output_schema:
-            raise InvalidSchemaException("Original schema and schema-to-merge are not compatible")
+            raise InvalidSchemaError("Original schema and schema-to-merge are not compatible")
 
-    def get_joint_name_aliases(self) -> Dict[str, str]:
+    def get_joint_name_aliases(self) -> dict[str, str]:
         """Get combined name mappings from input and output schemas."""
         joint_mapping = {}
         joint_mapping.update(self.input_schema.name_mapping)

--- a/src/service/data/model_data.py
+++ b/src/service/data/model_data.py
@@ -1,10 +1,9 @@
 import logging
-from typing import List, Optional
 
 import numpy as np
 import pandas as pd
 
-from src.service.constants import INPUT_SUFFIX, OUTPUT_SUFFIX, METADATA_SUFFIX
+from src.service.constants import INPUT_SUFFIX, METADATA_SUFFIX, OUTPUT_SUFFIX
 from src.service.data.storage import get_global_storage_interface
 
 logger = logging.getLogger(__name__)
@@ -15,11 +14,11 @@ class ModelDataContainer:
         self,
         model_name: str,
         input_data: np.ndarray,
-        input_names: List[str],
+        input_names: list[str],
         output_data: np.ndarray,
-        output_names: List[str],
+        output_names: list[str],
         metadata: np.ndarray,
-        metadata_names: List[str],
+        metadata_names: list[str],
     ):
         self.model_name = model_name
         self.input_data = input_data
@@ -34,7 +33,7 @@ class ModelData:
     """Main interface for retrieving model data, e.g.
 
     model_data = ModelData("example-model-name")
-    input_data_array, output_data_array, metadata_array = model_data.data()
+    input_data_array, output_data_array, metadata_array = await model_data.data()
 
     """
 
@@ -56,13 +55,8 @@ class ModelData:
         # warn if we're missing one of the expected datasets
         dataset_checks = (input_exists, output_exists, metadata_exists)
         if not all(dataset_checks):
-            expected_datasets = [
-                self.input_dataset, self.output_dataset, self.metadata_dataset
-            ]
-            missing_datasets = [
-                dataset for idx, dataset in enumerate(expected_datasets)
-                if not dataset_checks[idx]
-            ]
+            expected_datasets = [self.input_dataset, self.output_dataset, self.metadata_dataset]
+            missing_datasets = [dataset for idx, dataset in enumerate(expected_datasets) if not dataset_checks[idx]]
             logger.warning(
                 f"Not all datasets present for model {self.model_name}: "
                 f"missing {missing_datasets}. This could be indicative of "
@@ -80,7 +74,7 @@ class ModelData:
         metadata_rows = await storage_interface.dataset_rows(self.metadata_dataset)
         return input_rows, output_rows, metadata_rows
 
-    async def shapes(self) -> tuple[List[int], List[int], List[int]]:
+    async def shapes(self) -> tuple[list[int], list[int], list[int]]:
         """
         Get the shapes of the input, output, and metadata datasets that exist in a model dataset
         """
@@ -90,7 +84,7 @@ class ModelData:
         metadata_shape = await storage_interface.dataset_shape(self.metadata_dataset)
         return input_shape, output_shape, metadata_shape
 
-    async def column_names(self) -> tuple[List[str], List[str], List[str]]:
+    async def column_names(self) -> tuple[list[str], list[str], list[str]]:
         storage_interface = get_global_storage_interface()
         input_names = await storage_interface.get_aliased_column_names(self.input_dataset)
         output_names = await storage_interface.get_aliased_column_names(self.output_dataset)
@@ -99,7 +93,7 @@ class ModelData:
 
         return input_names, output_names, metadata_names
 
-    async def original_column_names(self) -> tuple[List[str], List[str], List[str]]:
+    async def original_column_names(self) -> tuple[list[str], list[str], list[str]]:
         storage_interface = get_global_storage_interface()
         input_names = await storage_interface.get_original_column_names(self.input_dataset)
         output_names = await storage_interface.get_original_column_names(self.output_dataset)
@@ -107,8 +101,9 @@ class ModelData:
 
         return input_names, output_names, metadata_names
 
-    async def data(self, start_row=0, n_rows=None, get_input=True, get_output=True, get_metadata=True) \
-            -> tuple[Optional[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]]:
+    async def data(
+        self, start_row=0, n_rows=None, get_input=True, get_output=True, get_metadata=True
+    ) -> tuple[np.ndarray | None, np.ndarray | None, np.ndarray | None]:
         """
         Get data from a saved model
 
@@ -146,32 +141,26 @@ class ModelData:
         # Check if metadata or columns are missing
         if metadata is None or metadata_cols is None:
             logger.warning(
-                f"Metadata or metadata columns missing for model "
-                f"{self.model_name}; returning empty DataFrame."
+                f"Metadata or metadata columns missing for model {self.model_name}; returning empty DataFrame."
             )
             return pd.DataFrame()
 
         # Check if metadata is empty
         if len(metadata) == 0 or len(metadata_cols) == 0:
             logger.warning(
-                f"Metadata or metadata columns empty for model "
-                f"{self.model_name}; returning empty DataFrame."
+                f"Metadata or metadata columns empty for model {self.model_name}; returning empty DataFrame."
             )
             return pd.DataFrame()
 
         # Validate that metadata rows are properly formatted
         if not all(isinstance(row, (list, tuple, np.ndarray)) for row in metadata):
-            logger.warning(
-                f"Metadata format is invalid for model {self.model_name}; "
-                f"returning empty DataFrame."
-            )
+            logger.warning(f"Metadata format is invalid for model {self.model_name}; returning empty DataFrame.")
             return pd.DataFrame()
 
         # Check if columns and data are aligned
         if not all(len(row) == len(metadata_cols) for row in metadata):
             logger.warning(
-                f"Metadata rows and columns are not aligned for model "
-                f"{self.model_name}; returning empty DataFrame."
+                f"Metadata rows and columns are not aligned for model {self.model_name}; returning empty DataFrame."
             )
             return pd.DataFrame()
 

--- a/tests/service/data/test_utils.py
+++ b/tests/service/data/test_utils.py
@@ -3,17 +3,17 @@ ModelMesh protobuf testing utils.
 """
 
 import base64
-import random
-from typing import Dict, List, Tuple, Any, Optional, Union
+import uuid
+from typing import Any
 
 import numpy as np
 
 try:
     from src.proto.grpc_predict_v2_pb2 import (
-        ModelInferRequest,
-        ModelInferResponse,
         InferParameter,
         InferTensorContents,
+        ModelInferRequest,
+        ModelInferResponse,
     )
 except ImportError:
     print("Warning: Protobuf classes not available. Run generate_protos.py first.")
@@ -25,7 +25,7 @@ class ModelMeshTestData:
     """
 
     @staticmethod
-    def create_infer_parameter(value: Union[bool, int, str]) -> InferParameter:
+    def create_infer_parameter(value: bool | int | str) -> InferParameter:
         """Create an InferParameter with the correct type based on value."""
         param = InferParameter()
         if isinstance(value, bool):
@@ -37,7 +37,7 @@ class ModelMeshTestData:
         return param
 
     @staticmethod
-    def generate_data(rows: int, cols: int, datatype: str, offset: int = 0) -> Tuple[np.ndarray, Any]:
+    def generate_data(rows: int, cols: int, datatype: str, offset: int = 0) -> tuple[np.ndarray, Any]:
         """
         Create test data based on the datatype.
         Returns the NumPy array and the corresponding value for InferTensorContents.
@@ -100,8 +100,8 @@ class ModelMeshTestData:
         cols: int,
         datatype: str,
         offset: int = 0,
-        parameters: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[ModelInferRequest.InferInputTensor, np.ndarray]:
+        parameters: dict[str, Any] | None = None,
+    ) -> tuple[ModelInferRequest.InferInputTensor, np.ndarray]:
         """Generate an input tensor with test data."""
         tensor = ModelInferRequest.InferInputTensor()
         tensor.name = name
@@ -121,7 +121,7 @@ class ModelMeshTestData:
     @staticmethod
     def generate_output_tensor(
         name: str, rows: int, cols: int, datatype: str, offset: int = 0
-    ) -> Tuple[ModelInferResponse.InferOutputTensor, np.ndarray]:
+    ) -> tuple[ModelInferResponse.InferOutputTensor, np.ndarray]:
         """Generate an output tensor with test data."""
         tensor = ModelInferResponse.InferOutputTensor()
         tensor.name = name
@@ -137,14 +137,14 @@ class ModelMeshTestData:
     @staticmethod
     def generate_model_infer_request(
         model_name: str,
-        input_tensors: List[Tuple[str, int, int, str, int, Optional[Dict[str, Any]]]],
-    ) -> Tuple[ModelInferRequest, Dict[str, np.ndarray]]:
+        input_tensors: list[tuple[str, int, int, str, int, dict[str, Any] | None]],
+    ) -> tuple[ModelInferRequest, dict[str, np.ndarray]]:
         """
         Generate a ModelInferRequest with the specified input tensors.
         """
         request = ModelInferRequest()
         request.model_name = model_name
-        request.id = f"test-request-{random.randint(1000, 9999)}"
+        request.id = f"test-request-{uuid.uuid4().hex[:8]}"
 
         data_dict = {}
 
@@ -161,8 +161,8 @@ class ModelMeshTestData:
         model_name: str,
         model_version: str,
         request_id: str,
-        output_tensors: List[Tuple[str, int, int, str, int]],
-    ) -> Tuple[ModelInferResponse, Dict[str, np.ndarray]]:
+        output_tensors: list[tuple[str, int, int, str, int]],
+    ) -> tuple[ModelInferResponse, dict[str, np.ndarray]]:
         """
         Generate a ModelInferResponse with the specified output tensors.
         """
@@ -184,9 +184,9 @@ class ModelMeshTestData:
     @staticmethod
     def generate_test_payloads(
         model_name: str,
-        input_tensor_specs: List[Tuple[str, int, int, str, int, Optional[Dict[str, Any]]]],
-        output_tensor_specs: List[Tuple[str, int, int, str, int]],
-    ) -> Tuple[dict, dict, dict, dict]:
+        input_tensor_specs: list[tuple[str, int, int, str, int, dict[str, Any] | None]],
+        output_tensor_specs: list[tuple[str, int, int, str, int]],
+    ) -> tuple[dict, dict, dict, dict]:
         """
         Generate test input and output payloads for ModelMesh testing.
         """


### PR DESCRIPTION
## Summary

Focused data layer fixes: PEP 8 exception naming, async docstring accuracy, and security best practice for test IDs.

**Jira:** RHOAIENG-57849, RHOAIENG-55581

### Changes

**`exceptions.py`:** Rename `InvalidSchemaException` → `InvalidSchemaError` (PEP 8: exceptions should use `Error` suffix, not `Exception`). Resolves CodeRabbit issue #1 from PR #117.

**`storage_metadata.py`:** Update all `InvalidSchemaException` references to `InvalidSchemaError`.

**`model_data.py`:** Fix docstring: `model_data.data()` → `await model_data.data()` since `data()` is async. Resolves CodeRabbit issue #4.

**`test_utils.py`:** Replace `random.randint()` with `uuid.uuid4()` for test request IDs (S311 — avoid insecure random for identifiers).

### Scope note

The original plan (PR #2) included larger refactors (StorageMetadataConfig, parser dispatch table, PVC/MariaDB lint suppressions). These were scoped for PR #117 which attempted to change StorageMetadata's `__init__` and broke callers. Since main's StorageMetadata works correctly, the Pydantic config wrapper adds indirection without functional benefit. Formatting and lint suppressions are deferred to PR #5 (strict linting).

### Known CI status

| Check | Status | Notes |
|---|---|---|
| test (3.12) | ✅ expected | 58 data layer tests pass locally |
| test (3.14) | ✅ expected | |
| bandit-scan | ✅ expected | |
| build-and-push-ci | ❌ expected | Pre-existing: `pull_request_target` runs main's workflow. Fix in PR #118. |
| pre-commit.ci | ❌ expected | Pre-existing: missing `.flake8`. Fixed by PR #118. |

## Test plan

- [x] `uv run pytest tests/service/data/ tests/service/test_consumer_endpoint_reconciliation.py` — 58 passed, 2 skipped
- [x] `uv run pytest tests/endpoints/ --ignore=tests/endpoints/test_upload_endpoint_maria.py` — 115 passed
- [x] `uv run ruff check` — clean on all modified files
- [x] `uv run pyrefly check` — 1 pre-existing error (model_data.py shapes return type), unchanged from main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align data layer error naming, async usage, and test ID generation with project conventions and security guidance.

Bug Fixes:
- Correct the ModelData usage docstring to reflect that data() is an async method that must be awaited.

Enhancements:
- Rename InvalidSchemaException to InvalidSchemaError and update its usages to follow Python exception naming conventions.
- Modernize type hints in data and test utilities to use built-in collection generics and more precise union syntax.
- Tidy logging and dataset existence checks in ModelData for clearer warnings and readability.

Tests:
- Use UUID-based request IDs in data-layer test utilities instead of random integers to follow secure identifier practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated schema validation exception naming for consistency
  * Changed request ID generation to UUID-based format
  * Modernized type annotations across data service modules and tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->