### PR TITLE
fix(drift): register Jensen-Shannon divergence router in main app

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,7 @@ from src.endpoints.metadata import router as metadata_router
 
 # from src.endpoints.drift_metrics import router as drift_metrics_router
 from src.endpoints.metrics.drift.compare_means import router as drift_comparemeans_router
+from src.endpoints.metrics.drift.jensen_shannon import router as drift_jensenshannon_router
 from src.endpoints.metrics.drift.kolmogorov_smirnov import router as drift_kstest_router
 from src.endpoints.metrics.fairness.group.dir import router as dir_router
 from src.endpoints.metrics.fairness.group.spd import router as spd_router
@@ -128,6 +129,12 @@ app.include_router(
     drift_comparemeans_router,
     tags=[
         "Drift Metrics: CompareMeans",
+    ],
+)
+app.include_router(
+    drift_jensenshannon_router,
+    tags=[
+        "Drift Metrics: JensenShannon",
     ],
 )
 app.include_router(


### PR DESCRIPTION
## Summary
- The Jensen-Shannon divergence endpoint (`/metrics/drift/jensenshannon`) was fully implemented in `src/endpoints/metrics/drift/jensen_shannon.py` but its router was never imported or registered in `src/main.py`, making it invisible to API consumers.
- This one-line fix adds the import and `app.include_router()` call to expose the already-complete endpoint.

## Test plan
- [ ] Verify `/metrics/drift/jensenshannon` responds to POST requests
- [ ] Verify `/metrics/drift/jensenshannon/definition` returns the metric definition
- [ ] Verify `/metrics/drift/jensenshannon/request` (POST/DELETE/GET) scheduling endpoints work
- [ ] Confirm no regressions on existing drift endpoints (`/metrics/drift/kstest`, `/metrics/drift/comparemeans`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Bug Fixes:
- Register the Jensen-Shannon drift metrics router in the main app so its endpoints become accessible to API consumers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Jensen Shannon drift metrics capability for enhanced drift detection and analysis alongside existing drift metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->