### PR TITLE
Enable parallel test execution with pytest-xdist

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -118,7 +118,7 @@ jobs:
         run: mariadb -u trustyai --password=trustyai -D trustyai-database -h 127.0.0.1 < tests/resources/legacy_database_dump.sql  # pragma: allowlist secret
 
       - name: Run tests with pytest
-        run: uv run pytest tests/ -v --cov=src --cov-report=xml
+        run: uv run pytest tests/ -v --cov=src --cov-report=xml -n auto --maxprocesses=4
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -118,7 +118,7 @@ jobs:
         run: mariadb -u trustyai --password=trustyai -D trustyai-database -h 127.0.0.1 < tests/resources/legacy_database_dump.sql  # pragma: allowlist secret
 
       - name: Run tests with pytest
-        run: uv run pytest tests/ -v --cov=src --cov-report=xml -n auto --maxprocesses=4
+        run: uv run pytest tests/ -v --cov=src --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ ignore = [
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"
-addopts = "--dist=loadgroup"
+addopts = "--dist=loadgroup -n 4"
 
 [tool.bandit]
 exclude_dirs = ["tests/"]


### PR DESCRIPTION
## Summary
Enable parallel test execution using pytest-xdist to improve test performance. Configuration is centralized in `pyproject.toml` to ensure consistent behavior between local development and CI.

## Changes
- **Centralized Configuration**: Added `-n 4` to `pytest.ini_options.addopts` in `pyproject.toml`
- **CI Cleanup**: Removed parallel flags from GitHub Actions workflow (now inherited from config)
- **Consistent Behavior**: Local development and CI use identical test execution settings
- **Database Safety**: Existing MariaDB tests use `@pytest.mark.xdist_group("mariadb")` for coordination

## Benefits
- **Faster Tests**: Utilizes 4 parallel workers in both local and CI environments  
- **Better Performance**: Especially beneficial for larger test suites
- **Consistent Experience**: Eliminates "works locally but not in CI" discrepancies
- **Safe Coordination**: MariaDB tests properly grouped to avoid conflicts
- **Developer Friendly**: No need to remember parallel flags - works automatically

## Technical Details
- Uses `pytest-xdist[psutil]>=3.8.0` (already in dependencies)
- Load group scheduling configured with `--dist=loadgroup` 
- Fixed worker count of 4 (simpler than auto-detection with caps)
- Compatible with coverage reporting and all existing test infrastructure

## Configuration
**pyproject.toml**:
```toml
[tool.pytest.ini_options]
addopts = "--dist=loadgroup -n 4"
```

**CI workflow** (simplified):
```bash
uv run pytest tests/ -v --cov=src --cov-report=xml
```

## Usage Examples
```bash
# Run tests (automatically parallel)
uv run pytest tests/ -v

# With coverage (same as CI)  
uv run pytest tests/ -v --cov=src --cov-report=xml

# Override to sequential if needed
uv run pytest tests/ -v -n 0
```

## Test Results
- ✅ Parallel execution works correctly with coverage reporting
- ✅ MariaDB tests properly coordinated with xdist_group markers  
- ✅ No test failures introduced by parallelization
- ✅ Local development matches CI behavior exactly

## Related
- pytest-xdist: https://github.com/pytest-dev/pytest-xdist
- Addresses Sourcery feedback on configuration centralization
- Follows best practices for pytest-xdist setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)