### PR TITLE
feat(metrics): add Batch Mean metric, deprecate Identity

### DIFF
--- a/src/endpoints/metrics/batch_mean.py
+++ b/src/endpoints/metrics/batch_mean.py
@@ -1,0 +1,327 @@
+"""Batch Mean metric endpoint.
+
+Each invocation computes the arithmetic mean of a column's last N data
+points (controlled by ``batchSize``). The Prometheus scheduler calls this
+every scrape interval, exposing the result as a gauge. Because the data
+window slides forward with each new inference, the time series of scraped
+gauge values forms a moving average — Prometheus handles the temporal
+dimension, so this code only needs to produce a single scalar per call.
+"""
+
+import logging
+import uuid
+from http import HTTPStatus
+
+import numpy as np
+import pandas as pd
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from src.service.data.datasources.data_source import DataSource
+from src.service.data.shared_data_source import get_shared_data_source
+from src.service.payloads.metrics.base_metric_request import BaseMetricRequest
+from src.service.prometheus.metric_value_carrier import MetricValueCarrier
+from src.service.prometheus.prometheus_scheduler import PrometheusScheduler
+from src.service.prometheus.shared_prometheus_scheduler import (
+    get_shared_prometheus_scheduler,
+)
+from src.service.utils.logging_utils import log_deprecated_endpoint
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+METRIC_NAME = "BatchMean"
+DEPRECATED_METRIC_NAME = "Identity"
+DEFAULT_BATCH_SIZE = 100
+
+
+def get_prometheus_scheduler() -> PrometheusScheduler:
+    """Get the shared prometheus scheduler instance."""
+    return get_shared_prometheus_scheduler()
+
+
+def get_data_source() -> DataSource:
+    """Get the shared data source instance."""
+    return get_shared_data_source()
+
+
+class ScheduleId(BaseModel):
+    """Identifier for a scheduled metric computation."""
+
+    requestId: str
+
+
+class BatchMeanRequest(BaseMetricRequest):
+    """Request parameters for the Batch Mean metric."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    model_id: str = Field(alias="modelId")
+    metric_name: str | None = Field(default=None, alias="metricName")
+    request_name: str | None = Field(default=None, alias="requestName")
+    batch_size: int = Field(default=DEFAULT_BATCH_SIZE, ge=1, alias="batchSize")
+
+    column_name: str = Field(alias="columnName")
+    lower_threshold: float | None = Field(default=None, alias="lowerThreshold")
+    upper_threshold: float | None = Field(default=None, alias="upperThreshold")
+
+    @model_validator(mode="after")
+    def _set_default_metric_name(self) -> "BatchMeanRequest":
+        if self.metric_name is None:
+            self.metric_name = METRIC_NAME
+        return self
+
+    def retrieve_tags(self) -> dict[str, str]:
+        """Return Prometheus labels for this metric request."""
+        tags = self.retrieve_default_tags()
+        tags["columnName"] = self.column_name
+        return tags
+
+
+def calculate_batch_mean_metric(
+    dataframe: pd.DataFrame,
+    request: BatchMeanRequest,
+) -> MetricValueCarrier:
+    """Calculate the mean of a column's values over the last N data points.
+
+    Registered with the metrics directory and called by the scheduler.
+    """
+    column_name = request.column_name
+
+    if column_name not in dataframe.columns:
+        msg = f"Column '{column_name}' not found in data"
+        raise ValueError(msg)
+
+    values = dataframe[column_name].to_numpy()
+    try:
+        float_values = values.astype(float)
+    except (ValueError, TypeError) as e:
+        msg = f"Column '{column_name}' contains non-numeric data"
+        raise TypeError(msg) from e
+    numeric_values = float_values[~np.isnan(float_values)]
+
+    if len(numeric_values) == 0:
+        logger.warning(
+            "No numeric values found in column '%s'. Returning NaN.",
+            column_name,
+        )
+        return MetricValueCarrier(float("nan"))
+
+    mean_value = float(np.mean(numeric_values))
+    logger.debug(
+        "Batch mean calculation result for '%s': %.4f", column_name, mean_value
+    )
+    return MetricValueCarrier(mean_value)
+
+
+def register_batch_mean_calculator() -> None:
+    """Register the BatchMean calculator with the global metrics directory."""
+    scheduler = get_prometheus_scheduler()
+    if scheduler and scheduler.metrics_directory:
+        scheduler.metrics_directory.register(METRIC_NAME, calculate_batch_mean_metric)
+        logger.info("BatchMean calculator registered with metrics directory")
+
+
+try:
+    register_batch_mean_calculator()
+except (AttributeError, TypeError) as e:
+    logger.warning("Could not register BatchMean calculator on import: %s", e)
+
+
+# ============================================================================
+# BatchMean endpoints
+# ============================================================================
+
+
+@router.post("/metrics/batchmean")
+async def compute_batch_mean(request: BatchMeanRequest) -> dict:
+    """Compute the mean of a column's last N values."""
+    logger.info(
+        "Computing BatchMean for model: %s, column: %s",
+        request.model_id,
+        request.column_name,
+    )
+
+    data_source = get_data_source()
+    batch_size = request.batch_size or DEFAULT_BATCH_SIZE
+
+    dataframe = await data_source.get_organic_dataframe(request.model_id, batch_size)
+
+    if dataframe.empty:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail=f"No data found for model: {request.model_id}",
+        )
+
+    result = calculate_batch_mean_metric(dataframe, request)
+    value = result.get_value()
+
+    response: dict = {
+        "name": METRIC_NAME,
+        "value": value,
+        "type": "BATCH_MEAN",
+        "specificDefinition": (
+            f"The batch mean of the last {batch_size} values of "
+            f"column '{request.column_name}' in model {request.model_id} "
+            f"is {value:.4f}."
+        ),
+    }
+
+    if request.lower_threshold is not None or request.upper_threshold is not None:
+        lower = (
+            request.lower_threshold
+            if request.lower_threshold is not None
+            else float("-inf")
+        )
+        upper = (
+            request.upper_threshold
+            if request.upper_threshold is not None
+            else float("inf")
+        )
+        response["thresholds"] = {
+            "lowerBound": request.lower_threshold,
+            "upperBound": request.upper_threshold,
+            "outsideBounds": value < lower or value > upper,
+        }
+
+    return response
+
+
+@router.get("/metrics/batchmean/definition")
+async def get_batch_mean_definition() -> dict:
+    """Provide a general definition of the Batch Mean metric."""
+    return {
+        "name": "Batch Mean",
+        "description": (
+            "Returns the arithmetic mean of a model's last N feature or output values "
+            "for a specified column, where N is the batch size."
+        ),
+    }
+
+
+@router.post("/metrics/batchmean/definition")
+async def interpret_batch_mean_value(request: BatchMeanRequest) -> dict:
+    """Provide a specific, plain-english interpretation of a Batch Mean value."""
+    return {
+        "interpretation": (
+            f"The batch mean of column '{request.column_name}' "
+            f"tracks the mean of the last {request.batch_size} values, "
+            f"useful for monitoring trends and detecting shifts."
+        ),
+    }
+
+
+@router.post("/metrics/batchmean/request")
+async def schedule_batch_mean(request: BatchMeanRequest) -> dict:
+    """Schedule a recurring computation of Batch Mean metric."""
+    request_id = uuid.uuid4()
+    logger.info("Scheduling BatchMean computation with ID: %s", request_id)
+
+    scheduler = get_prometheus_scheduler()
+    await scheduler.register(METRIC_NAME, request_id, request)
+
+    logger.info("Successfully scheduled BatchMean computation with ID: %s", request_id)
+    return {"requestId": str(request_id)}
+
+
+@router.delete("/metrics/batchmean/request")
+async def delete_batch_mean_schedule(schedule: ScheduleId) -> dict:
+    """Delete a recurring computation of Batch Mean metric."""
+    logger.info("Deleting BatchMean schedule: %s", schedule.requestId)
+
+    scheduler = get_prometheus_scheduler()
+
+    try:
+        request_uuid = uuid.UUID(schedule.requestId)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST, detail="Invalid request ID format"
+        ) from e
+
+    await scheduler.delete(METRIC_NAME, request_uuid)
+
+    logger.info("Successfully deleted BatchMean schedule: %s", schedule.requestId)
+    return {
+        "status": "success",
+        "message": f"Schedule {schedule.requestId} deleted",
+    }
+
+
+@router.get("/metrics/batchmean/requests")
+async def list_batch_mean_requests() -> dict:
+    """List the currently scheduled computations of Batch Mean metric."""
+    scheduler = get_prometheus_scheduler()
+    bm_requests = scheduler.get_requests(METRIC_NAME)
+
+    requests_list = []
+    for request_id, request in bm_requests.items():
+        if hasattr(request, "model_id") and hasattr(request, "column_name"):
+            requests_list.append(
+                {
+                    "requestId": str(request_id),
+                    "modelId": request.model_id,
+                    "metricName": METRIC_NAME,
+                    "batchSize": getattr(request, "batch_size", DEFAULT_BATCH_SIZE),
+                    "columnName": request.column_name,
+                    "lowerThreshold": getattr(request, "lower_threshold", None),
+                    "upperThreshold": getattr(request, "upper_threshold", None),
+                }
+            )
+        else:
+            logger.warning(
+                "Skipping malformed BatchMean request %s: missing required attributes",
+                request_id,
+            )
+
+    return {"requests": requests_list}
+
+
+# ============================================================================
+# Deprecated Identity endpoints (backward compatibility)
+# ============================================================================
+
+
+class IdentityMetricRequest(BatchMeanRequest):
+    """Deprecated: Use BatchMeanRequest instead."""
+
+
+@router.post("/metrics/identity", deprecated=True)
+async def compute_identity_metric(request: IdentityMetricRequest) -> dict:
+    """Compute identity metric (deprecated). Use /metrics/batchmean instead."""
+    log_deprecated_endpoint(logger, DEPRECATED_METRIC_NAME, METRIC_NAME)
+    return await compute_batch_mean(request)
+
+
+@router.get("/metrics/identity/definition", deprecated=True)
+async def get_identity_definition() -> dict:
+    """Get identity metric definition (deprecated). Use /metrics/batchmean/definition instead."""
+    log_deprecated_endpoint(logger, DEPRECATED_METRIC_NAME, METRIC_NAME)
+    return await get_batch_mean_definition()
+
+
+@router.post("/metrics/identity/definition", deprecated=True)
+async def interpret_identity_value(request: IdentityMetricRequest) -> dict:
+    """Interpret identity metric value (deprecated). Use /metrics/batchmean/definition instead."""
+    log_deprecated_endpoint(logger, DEPRECATED_METRIC_NAME, METRIC_NAME)
+    return await interpret_batch_mean_value(request)
+
+
+@router.post("/metrics/identity/request", deprecated=True)
+async def schedule_identity(request: IdentityMetricRequest) -> dict:
+    """Schedule identity metric (deprecated). Use /metrics/batchmean/request instead."""
+    log_deprecated_endpoint(logger, DEPRECATED_METRIC_NAME, METRIC_NAME)
+    return await schedule_batch_mean(request)
+
+
+@router.delete("/metrics/identity/request", deprecated=True)
+async def delete_identity_schedule(schedule: ScheduleId) -> dict:
+    """Delete identity metric schedule (deprecated). Use /metrics/batchmean/request instead."""
+    log_deprecated_endpoint(logger, DEPRECATED_METRIC_NAME, METRIC_NAME)
+    return await delete_batch_mean_schedule(schedule)
+
+
+@router.get("/metrics/identity/requests", deprecated=True)
+async def list_identity_requests() -> dict:
+    """List identity metric schedules (deprecated). Use /metrics/batchmean/requests instead."""
+    log_deprecated_endpoint(logger, DEPRECATED_METRIC_NAME, METRIC_NAME)
+    return await list_batch_mean_requests()

--- a/src/main.py
+++ b/src/main.py
@@ -25,13 +25,13 @@ from src.endpoints.data.data_upload import router as data_upload_router
 from src.endpoints.explainers.global_explainer import router as explainers_global_router
 from src.endpoints.explainers.local_explainer import router as explainers_local_router
 from src.endpoints.metadata import router as metadata_router
+from src.endpoints.metrics.batch_mean import router as batch_mean_router
 from src.endpoints.metrics.drift.compare_means import (
     router as drift_comparemeans_router,
 )
 from src.endpoints.metrics.drift.kolmogorov_smirnov import router as drift_kstest_router
 from src.endpoints.metrics.fairness.group.dir import router as dir_router
 from src.endpoints.metrics.fairness.group.spd import router as spd_router
-from src.endpoints.metrics.identity.identity_endpoint import router as identity_router
 from src.endpoints.metrics.metrics_info import router as metrics_info_router
 
 # Middleware
@@ -155,7 +155,7 @@ app.include_router(
     spd_router,
     tags=["Fairness Metrics: Group: Statistical Parity Difference"],
 )
-app.include_router(identity_router, tags=["Identity Endpoint"])
+app.include_router(batch_mean_router, tags=["Metrics: Batch Mean"])
 app.include_router(metadata_router, tags=["Service Metadata"])
 app.include_router(metrics_info_router, tags=["Metrics Information Endpoint"])
 

--- a/tests/endpoints/metrics/test_batch_mean.py
+++ b/tests/endpoints/metrics/test_batch_mean.py
@@ -1,0 +1,374 @@
+"""Integration tests for the Batch Mean metric endpoints."""
+
+from http import HTTPStatus
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import numpy as np
+import pandas as pd
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.endpoints.metrics.batch_mean import BatchMeanRequest, router
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+MODULE = "src.endpoints.metrics.batch_mean"
+
+
+def _make_dataframe(n: int = 100, seed: int = 42) -> pd.DataFrame:
+    """Create a reproducible test dataframe with numeric columns."""
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame(
+        {
+            "feature1": rng.standard_normal(n),
+            "feature2": rng.uniform(0, 10, n),
+            "output": rng.integers(0, 2, n).astype(float),
+        }
+    )
+
+
+def _base_payload(**overrides: str | float) -> dict:
+    """Create a base request payload with optional overrides."""
+    payload: dict[str, str | float] = {
+        "modelId": "test-model",
+        "columnName": "feature1",
+        "batchSize": 100,
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestBatchMeanCompute:
+    """Tests for the POST /metrics/batchmean endpoint."""
+
+    @patch(f"{MODULE}.get_data_source")
+    def test_compute_returns_valid_response(self, mock_ds: MagicMock) -> None:
+        """Valid request returns metric name, type, value, and definition."""
+        mock_data_source = MagicMock()
+        mock_data_source.get_organic_dataframe = AsyncMock(
+            return_value=_make_dataframe()
+        )
+        mock_ds.return_value = mock_data_source
+
+        response = client.post("/metrics/batchmean", json=_base_payload())
+
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()
+        assert data["name"] == "BatchMean"
+        assert data["type"] == "BATCH_MEAN"
+        assert isinstance(data["value"], float)
+        assert "specificDefinition" in data
+
+    @patch(f"{MODULE}.get_data_source")
+    def test_compute_correct_mean(self, mock_ds: MagicMock) -> None:
+        """Mean of [2, 4, 6, 8, 10] is 6.0."""
+        df = pd.DataFrame({"col": [2.0, 4.0, 6.0, 8.0, 10.0]})
+        mock_data_source = MagicMock()
+        mock_data_source.get_organic_dataframe = AsyncMock(return_value=df)
+        mock_ds.return_value = mock_data_source
+
+        response = client.post(
+            "/metrics/batchmean", json=_base_payload(columnName="col")
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["value"] == 6.0  # noqa: PLR2004
+
+    @patch(f"{MODULE}.get_data_source")
+    def test_compute_with_thresholds_inside(self, mock_ds: MagicMock) -> None:
+        """Value within threshold bounds reports outsideBounds=False."""
+        df = pd.DataFrame({"col": [5.0, 5.0, 5.0]})
+        mock_data_source = MagicMock()
+        mock_data_source.get_organic_dataframe = AsyncMock(return_value=df)
+        mock_ds.return_value = mock_data_source
+
+        response = client.post(
+            "/metrics/batchmean",
+            json=_base_payload(
+                columnName="col", lowerThreshold=0.0, upperThreshold=10.0
+            ),
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()
+        assert "thresholds" in data
+        assert data["thresholds"]["outsideBounds"] is False
+
+    @patch(f"{MODULE}.get_data_source")
+    def test_compute_with_thresholds_outside(self, mock_ds: MagicMock) -> None:
+        """Value outside threshold bounds reports outsideBounds=True."""
+        df = pd.DataFrame({"col": [100.0, 100.0]})
+        mock_data_source = MagicMock()
+        mock_data_source.get_organic_dataframe = AsyncMock(return_value=df)
+        mock_ds.return_value = mock_data_source
+
+        response = client.post(
+            "/metrics/batchmean",
+            json=_base_payload(
+                columnName="col", lowerThreshold=0.0, upperThreshold=10.0
+            ),
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["thresholds"]["outsideBounds"] is True
+
+    @patch(f"{MODULE}.get_data_source")
+    def test_compute_no_thresholds_omits_field(self, mock_ds: MagicMock) -> None:
+        """Response omits thresholds when none are specified."""
+        mock_data_source = MagicMock()
+        mock_data_source.get_organic_dataframe = AsyncMock(
+            return_value=_make_dataframe()
+        )
+        mock_ds.return_value = mock_data_source
+
+        response = client.post("/metrics/batchmean", json=_base_payload())
+
+        assert response.status_code == HTTPStatus.OK
+        assert "thresholds" not in response.json()
+
+    @patch(f"{MODULE}.get_data_source")
+    def test_compute_empty_data_returns_404(self, mock_ds: MagicMock) -> None:
+        """Empty dataframe returns 404."""
+        mock_data_source = MagicMock()
+        mock_data_source.get_organic_dataframe = AsyncMock(return_value=pd.DataFrame())
+        mock_ds.return_value = mock_data_source
+
+        response = client.post("/metrics/batchmean", json=_base_payload())
+        assert response.status_code == HTTPStatus.NOT_FOUND
+
+    @patch(f"{MODULE}.get_data_source")
+    def test_compute_missing_column_raises(self, mock_ds: MagicMock) -> None:
+        """Requesting a non-existent column raises ValueError."""
+        df = pd.DataFrame({"other_col": [1.0, 2.0]})
+        mock_data_source = MagicMock()
+        mock_data_source.get_organic_dataframe = AsyncMock(return_value=df)
+        mock_ds.return_value = mock_data_source
+
+        with pytest.raises(ValueError, match="not found"):
+            client.post(
+                "/metrics/batchmean",
+                json=_base_payload(columnName="nonexistent"),
+            )
+
+
+class TestBatchMeanDefinition:
+    """Tests for the definition and interpretation endpoints."""
+
+    def test_definition_returns_name_and_description(self) -> None:
+        """GET definition returns name and non-empty description."""
+        response = client.get("/metrics/batchmean/definition")
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()
+        assert "Batch Mean" in data["name"]
+        assert len(data["description"]) > 0
+
+    def test_interpret_value(self) -> None:
+        """POST definition returns an interpretation string."""
+        response = client.post(
+            "/metrics/batchmean/definition",
+            json=_base_payload(),
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert "interpretation" in response.json()
+
+
+class TestBatchMeanSchedule:
+    """Tests for scheduling and deleting metric computations."""
+
+    @patch(f"{MODULE}.get_prometheus_scheduler")
+    def test_schedule_returns_request_id(self, mock_sched_fn: MagicMock) -> None:
+        """Scheduling returns a UUID request ID."""
+        mock_sched = MagicMock()
+        mock_sched.register = AsyncMock(return_value=None)
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.post("/metrics/batchmean/request", json=_base_payload())
+
+        assert response.status_code == HTTPStatus.OK
+        assert "requestId" in response.json()
+        assert "-" in response.json()["requestId"]
+
+    @patch(f"{MODULE}.get_prometheus_scheduler")
+    def test_delete_schedule(self, mock_sched_fn: MagicMock) -> None:
+        """Deleting a valid schedule returns success."""
+        mock_sched = MagicMock()
+        mock_sched.delete = AsyncMock(return_value=None)
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.request(
+            "DELETE",
+            "/metrics/batchmean/request",
+            json={"requestId": "123e4567-e89b-12d3-a456-426614174000"},
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["status"] == "success"
+
+    @patch(f"{MODULE}.get_prometheus_scheduler")
+    def test_delete_invalid_uuid(self, mock_sched_fn: MagicMock) -> None:
+        """Deleting with an invalid UUID returns 400."""
+        mock_sched = MagicMock()
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.request(
+            "DELETE",
+            "/metrics/batchmean/request",
+            json={"requestId": "not-a-uuid"},
+        )
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+class TestBatchMeanList:
+    """Tests for listing scheduled metric computations."""
+
+    @patch(f"{MODULE}.get_prometheus_scheduler")
+    def test_list_empty(self, mock_sched_fn: MagicMock) -> None:
+        """Empty schedule returns empty list."""
+        mock_sched = MagicMock()
+        mock_sched.get_requests = MagicMock(return_value={})
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.get("/metrics/batchmean/requests")
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["requests"] == []
+
+    @patch(f"{MODULE}.get_prometheus_scheduler")
+    def test_list_with_requests(self, mock_sched_fn: MagicMock) -> None:
+        """Listing returns all scheduled requests with correct fields."""
+        num_requests = 3
+        mock_requests = {}
+        for i in range(num_requests):
+            req = MagicMock()
+            req.model_id = f"model-{i}"
+            req.column_name = "feature1"
+            req.batch_size = 100
+            req.lower_threshold = None
+            req.upper_threshold = None
+            mock_requests[uuid4()] = req
+        mock_sched = MagicMock()
+        mock_sched.get_requests = MagicMock(return_value=mock_requests)
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.get("/metrics/batchmean/requests")
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()
+        assert len(data["requests"]) == num_requests
+        for req in data["requests"]:
+            assert req["metricName"] == "BatchMean"
+            assert "columnName" in req
+
+    @patch(f"{MODULE}.get_prometheus_scheduler")
+    def test_list_filters_malformed(self, mock_sched_fn: MagicMock) -> None:
+        """Malformed requests are skipped, valid ones returned."""
+        mock_requests = {}
+        valid = MagicMock()
+        valid.model_id = "m1"
+        valid.column_name = "c1"
+        valid.batch_size = 100
+        valid.lower_threshold = None
+        valid.upper_threshold = None
+        mock_requests[uuid4()] = valid
+
+        malformed = MagicMock(spec=[])
+        mock_requests[uuid4()] = malformed
+
+        mock_sched = MagicMock()
+        mock_sched.get_requests = MagicMock(return_value=mock_requests)
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.get("/metrics/batchmean/requests")
+        assert response.status_code == HTTPStatus.OK
+        assert len(response.json()["requests"]) == 1
+
+    @patch(f"{MODULE}.get_prometheus_scheduler")
+    def test_list_exception_propagates(self, mock_sched_fn: MagicMock) -> None:
+        """Unhandled scheduler errors propagate as exceptions."""
+        mock_sched = MagicMock()
+        mock_sched.get_requests = MagicMock(side_effect=RuntimeError("DB error"))
+        mock_sched_fn.return_value = mock_sched
+
+        with pytest.raises(RuntimeError, match="DB error"):
+            client.get("/metrics/batchmean/requests")
+
+
+class TestDeprecatedIdentityEndpoints:
+    """Tests for backward-compatible /metrics/identity/* endpoints."""
+
+    @patch(f"{MODULE}.get_data_source")
+    def test_deprecated_compute(self, mock_ds: MagicMock) -> None:
+        """Deprecated compute forwards to BatchMean and returns correct value."""
+        df = pd.DataFrame({"feature1": [1.0, 2.0, 3.0]})
+        mock_data_source = MagicMock()
+        mock_data_source.get_organic_dataframe = AsyncMock(return_value=df)
+        mock_ds.return_value = mock_data_source
+
+        response = client.post("/metrics/identity", json=_base_payload())
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["name"] == "BatchMean"
+        assert response.json()["value"] == 2.0  # noqa: PLR2004
+
+    def test_deprecated_definition(self) -> None:
+        """Deprecated definition forwards to BatchMean definition."""
+        response = client.get("/metrics/identity/definition")
+        assert response.status_code == HTTPStatus.OK
+        assert "Batch Mean" in response.json()["name"]
+
+    @patch(f"{MODULE}.get_prometheus_scheduler")
+    def test_deprecated_schedule(self, mock_sched_fn: MagicMock) -> None:
+        """Deprecated schedule forwards to BatchMean schedule."""
+        mock_sched = MagicMock()
+        mock_sched.register = AsyncMock(return_value=None)
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.post("/metrics/identity/request", json=_base_payload())
+        assert response.status_code == HTTPStatus.OK
+        assert "requestId" in response.json()
+
+    @patch(f"{MODULE}.get_prometheus_scheduler")
+    def test_deprecated_delete(self, mock_sched_fn: MagicMock) -> None:
+        """Deprecated delete forwards to BatchMean delete."""
+        mock_sched = MagicMock()
+        mock_sched.delete = AsyncMock(return_value=None)
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.request(
+            "DELETE",
+            "/metrics/identity/request",
+            json={"requestId": "123e4567-e89b-12d3-a456-426614174000"},
+        )
+        assert response.status_code == HTTPStatus.OK
+
+    @patch(f"{MODULE}.get_prometheus_scheduler")
+    def test_deprecated_list(self, mock_sched_fn: MagicMock) -> None:
+        """Deprecated list forwards to BatchMean list."""
+        mock_sched = MagicMock()
+        mock_sched.get_requests = MagicMock(return_value={})
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.get("/metrics/identity/requests")
+        assert response.status_code == HTTPStatus.OK
+        assert "requests" in response.json()
+
+
+class TestBatchMeanRequest:
+    """Tests for BatchMeanRequest model validation."""
+
+    def test_model_validator_sets_metric_name(self) -> None:
+        """Default metric_name is set to BatchMean by model validator."""
+        request = BatchMeanRequest(modelId="test", columnName="col")
+        assert request.metric_name == "BatchMean"
+
+    def test_retrieve_tags(self) -> None:
+        """Tags include columnName and modelId."""
+        request = BatchMeanRequest(modelId="test", columnName="col")
+        tags = request.retrieve_tags()
+        assert tags["columnName"] == "col"
+        assert tags["modelId"] == "test"
+
+    def test_default_batch_size(self) -> None:
+        """Default batch_size matches the model field default."""
+        request = BatchMeanRequest(modelId="test", columnName="col")
+        assert request.batch_size == BatchMeanRequest.model_fields["batch_size"].default

--- a/tests/endpoints/metrics/test_batch_mean_unit.py
+++ b/tests/endpoints/metrics/test_batch_mean_unit.py
@@ -1,0 +1,92 @@
+"""Unit tests for calculate_batch_mean_metric."""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+
+from src.endpoints.metrics.batch_mean import (
+    BatchMeanRequest,
+    calculate_batch_mean_metric,
+)
+
+
+def _request(column: str = "col") -> BatchMeanRequest:
+    """Create a minimal BatchMeanRequest for testing."""
+    return BatchMeanRequest(modelId="test", columnName=column)
+
+
+class TestCalculateBatchMeanMetric:
+    """Tests for the core batch mean calculation function."""
+
+    def test_correct_mean(self) -> None:
+        """Mean of [2, 4, 6, 8, 10] is 6.0."""
+        df = pd.DataFrame({"col": [2.0, 4.0, 6.0, 8.0, 10.0]})
+        result = calculate_batch_mean_metric(df, _request())
+        assert result.get_value() == 6.0  # noqa: PLR2004
+
+    def test_single_value(self) -> None:
+        """Mean of a single value is that value."""
+        df = pd.DataFrame({"col": [42.0]})
+        result = calculate_batch_mean_metric(df, _request())
+        assert result.get_value() == 42.0  # noqa: PLR2004
+
+    def test_negative_values(self) -> None:
+        """Mean of symmetric negatives and positives is 0.0."""
+        df = pd.DataFrame({"col": [-3.0, -1.0, 1.0, 3.0]})
+        result = calculate_batch_mean_metric(df, _request())
+        assert result.get_value() == 0.0
+
+    def test_skips_nan_values(self) -> None:
+        """NaN values are filtered before computing the mean."""
+        df = pd.DataFrame({"col": [1.0, float("nan"), 3.0, float("nan"), 5.0]})
+        result = calculate_batch_mean_metric(df, _request())
+        assert result.get_value() == 3.0  # noqa: PLR2004
+
+    def test_all_nan_returns_nan(self) -> None:
+        """All-NaN column returns NaN."""
+        df = pd.DataFrame({"col": [float("nan"), float("nan")]})
+        result = calculate_batch_mean_metric(df, _request())
+        assert math.isnan(result.get_value())
+
+    def test_missing_column_raises(self) -> None:
+        """Requesting a non-existent column raises ValueError."""
+        df = pd.DataFrame({"other": [1.0, 2.0]})
+        with pytest.raises(ValueError, match="not found"):
+            calculate_batch_mean_metric(df, _request("nonexistent"))
+
+    def test_large_batch(self) -> None:
+        """Large batch mean matches numpy reference value."""
+        rng = np.random.default_rng(42)
+        values = rng.standard_normal(10_000)
+        df = pd.DataFrame({"col": values})
+        result = calculate_batch_mean_metric(df, _request())
+        assert result.get_value() == pytest.approx(np.mean(values), abs=1e-10)
+
+    def test_integer_column(self) -> None:
+        """Integer columns are handled correctly."""
+        df = pd.DataFrame({"col": [1, 2, 3, 4, 5]})
+        result = calculate_batch_mean_metric(df, _request())
+        assert result.get_value() == 3.0  # noqa: PLR2004
+
+    def test_string_column_raises(self) -> None:
+        """String columns raise TypeError with descriptive message."""
+        df = pd.DataFrame({"col": ["a", "b", "c"]})
+        with pytest.raises(TypeError, match="non-numeric"):
+            calculate_batch_mean_metric(df, _request())
+
+
+class TestBatchMeanRequestValidation:
+    """Tests for Pydantic validation on BatchMeanRequest."""
+
+    def test_batch_size_zero_rejected(self) -> None:
+        """batch_size=0 is rejected by ge=1 constraint."""
+        with pytest.raises(ValidationError, match="greater than or equal to 1"):
+            BatchMeanRequest(modelId="test", columnName="col", batchSize=0)
+
+    def test_batch_size_negative_rejected(self) -> None:
+        """Negative batch_size is rejected by ge=1 constraint."""
+        with pytest.raises(ValidationError, match="greater than or equal to 1"):
+            BatchMeanRequest(modelId="test", columnName="col", batchSize=-1)


### PR DESCRIPTION
## Jira

[RHOAIENG-67129](https://redhat.atlassian.net/browse/RHOAIENG-67129)

## Summary
- Add Batch Mean metric endpoint (`/metrics/batchmean`) that computes the arithmetic mean of a column's last N data points
- Prometheus scrapes this gauge each interval, so the time series forms a moving average — the service produces a single scalar per invocation
- Deprecated Identity metric endpoints (`/metrics/identity/*`) preserved as thin wrappers forwarding to Batch Mean
- `BatchMeanRequest` model with `batch_size >= 1` validation, NaN filtering, and non-numeric column detection
- Unit tests for core calculation + integration tests for all endpoints including deprecated aliases

## Test plan
- [x] `uv run pytest tests/endpoints/metrics/test_batch_mean.py tests/endpoints/metrics/test_batch_mean_unit.py -v`
- [x] Verify deprecated `/metrics/identity` endpoints still return correct results
- [x] Verify `batchSize=0` returns 422 validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
