### PR TITLE
fix(storage): add env var fallback for operator compatibility

### DIFF
--- a/src/service/data/storage/__init__.py
+++ b/src/service/data/storage/__init__.py
@@ -56,7 +56,7 @@ def get_storage_interface() -> MariaDBStorage | PVCStorage:
             data_directory=os.environ.get("STORAGE_DATA_FOLDER", "/tmp"),  # noqa: S108 -- fallback default for STORAGE_DATA_FOLDER env var
             data_file=os.environ.get("STORAGE_DATA_FILENAME", "trustyai.hdf5"),
         )
-    if storage_format == "MARIA":
+    if storage_format in ("MARIA", "DATABASE"):
         try:
             # Import MariaDB storage only when needed (optional dependency)
             from src.service.data.storage.maria.maria import (  # noqa: PLC0415 -- lazy import: mariadb is optional
@@ -67,12 +67,26 @@ def get_storage_interface() -> MariaDBStorage | PVCStorage:
             migration_str = os.environ.get("DATABASE_ATTEMPT_MIGRATION", "0").lower()
             attempt_migration = migration_str in ("1", "true", "yes", "on")
 
+            # Support both operator env vars and direct deployment env vars
+            # Operator (Quarkus-based): QUARKUS_DATASOURCE_USERNAME/PASSWORD, DATABASE_SERVICE/NAME
+            # Direct deployment: DATABASE_USERNAME/PASSWORD, DATABASE_HOST/DATABASE
+            user = os.environ.get("DATABASE_USERNAME") or os.environ.get(
+                "QUARKUS_DATASOURCE_USERNAME"
+            )
+            password = os.environ.get("DATABASE_PASSWORD") or os.environ.get(
+                "QUARKUS_DATASOURCE_PASSWORD"
+            )
+            host = os.environ.get("DATABASE_HOST") or os.environ.get("DATABASE_SERVICE")
+            database = os.environ.get("DATABASE_DATABASE") or os.environ.get(
+                "DATABASE_NAME"
+            )
+
             return MariaDBStorage(
-                user=os.environ.get("DATABASE_USERNAME"),
-                password=os.environ.get("DATABASE_PASSWORD"),
-                host=os.environ.get("DATABASE_HOST"),
+                user=user,
+                password=password,
+                host=host,
                 port=int(os.environ.get("DATABASE_PORT", "3306")),
-                database=os.environ.get("DATABASE_DATABASE"),
+                database=database,
                 attempt_migration=attempt_migration,
             )
         except ImportError as e:

--- a/src/service/data/storage/__init__.py
+++ b/src/service/data/storage/__init__.py
@@ -81,6 +81,20 @@ def get_storage_interface() -> MariaDBStorage | PVCStorage:
                 "DATABASE_NAME"
             )
 
+            # Validate required parameters before constructing MariaDBStorage
+            missing = []
+            if not user:
+                missing.append("DATABASE_USERNAME or QUARKUS_DATASOURCE_USERNAME")
+            if not password:
+                missing.append("DATABASE_PASSWORD or QUARKUS_DATASOURCE_PASSWORD")
+            if not host:
+                missing.append("DATABASE_HOST or DATABASE_SERVICE")
+            if not database:
+                missing.append("DATABASE_DATABASE or DATABASE_NAME")
+            if missing:
+                msg = f"MariaDB storage requires environment variables: {', '.join(missing)}"
+                raise ValueError(msg)
+
             return MariaDBStorage(
                 user=user,
                 password=password,

--- a/tests/service/data/test_storage_init.py
+++ b/tests/service/data/test_storage_init.py
@@ -12,6 +12,14 @@ from src.service.data.storage.pvc import PVCStorage
 DEFAULT_MARIADB_PORT = 3306
 ALTERNATE_MARIADB_PORT = 3307
 
+# Check if mariadb is available
+try:
+    import mariadb  # noqa: F401
+
+    HAS_MARIADB = True
+except ImportError:
+    HAS_MARIADB = False
+
 
 class TestStorageInterfaceEnvVars:
     """Test storage interface creation with different environment variable conventions."""
@@ -32,10 +40,7 @@ class TestStorageInterfaceEnvVars:
             assert storage.data_directory == "/tmp/test"  # noqa: S108
             assert storage.data_file == "test.hdf5"
 
-    @pytest.mark.skipif(
-        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
-        reason="mariadb extra not installed",
-    )
+    @pytest.mark.skipif(not HAS_MARIADB, reason="mariadb extra not installed")
     @patch("src.service.data.storage.maria.maria.MariaDBStorage")
     def test_mariadb_with_database_host_and_database(
         self, mock_storage: MagicMock
@@ -65,10 +70,7 @@ class TestStorageInterfaceEnvVars:
                 attempt_migration=False,
             )
 
-    @pytest.mark.skipif(
-        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
-        reason="mariadb extra not installed",
-    )
+    @pytest.mark.skipif(not HAS_MARIADB, reason="mariadb extra not installed")
     @patch("src.service.data.storage.maria.maria.MariaDBStorage")
     def test_mariadb_with_database_service_and_name(
         self, mock_storage: MagicMock
@@ -98,10 +100,7 @@ class TestStorageInterfaceEnvVars:
                 attempt_migration=False,
             )
 
-    @pytest.mark.skipif(
-        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
-        reason="mariadb extra not installed",
-    )
+    @pytest.mark.skipif(not HAS_MARIADB, reason="mariadb extra not installed")
     @patch("src.service.data.storage.maria.maria.MariaDBStorage")
     def test_mariadb_fallback_priority(self, mock_storage: MagicMock) -> None:
         """Test that DATABASE_HOST takes priority over DATABASE_SERVICE when both present."""
@@ -131,10 +130,7 @@ class TestStorageInterfaceEnvVars:
                 attempt_migration=False,
             )
 
-    @pytest.mark.skipif(
-        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
-        reason="mariadb extra not installed",
-    )
+    @pytest.mark.skipif(not HAS_MARIADB, reason="mariadb extra not installed")
     @patch("src.service.data.storage.maria.maria.MariaDBStorage")
     def test_mariadb_mixed_conventions(self, mock_storage: MagicMock) -> None:
         """Test MariaDB with mixed env var conventions (DATABASE_HOST + DATABASE_NAME)."""
@@ -162,10 +158,7 @@ class TestStorageInterfaceEnvVars:
                 attempt_migration=False,
             )
 
-    @pytest.mark.skipif(
-        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
-        reason="mariadb extra not installed",
-    )
+    @pytest.mark.skipif(not HAS_MARIADB, reason="mariadb extra not installed")
     @patch("src.service.data.storage.maria.maria.MariaDBStorage")
     def test_mariadb_with_database_format(self, mock_storage: MagicMock) -> None:
         """Test MariaDB with SERVICE_STORAGE_FORMAT=DATABASE (operator convention)."""
@@ -193,10 +186,7 @@ class TestStorageInterfaceEnvVars:
                 attempt_migration=False,
             )
 
-    @pytest.mark.skipif(
-        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
-        reason="mariadb extra not installed",
-    )
+    @pytest.mark.skipif(not HAS_MARIADB, reason="mariadb extra not installed")
     @patch("src.service.data.storage.maria.maria.MariaDBStorage")
     def test_mariadb_with_quarkus_credentials(self, mock_storage: MagicMock) -> None:
         """Test MariaDB with QUARKUS_DATASOURCE_USERNAME/PASSWORD (operator convention)."""
@@ -204,6 +194,8 @@ class TestStorageInterfaceEnvVars:
             os.environ,
             {
                 "SERVICE_STORAGE_FORMAT": "DATABASE",
+                "DATABASE_USERNAME": "",  # Explicitly clear to test fallback
+                "DATABASE_PASSWORD": "",  # Explicitly clear to test fallback
                 "QUARKUS_DATASOURCE_USERNAME": "quarkus_user",
                 "QUARKUS_DATASOURCE_PASSWORD": "quarkus_pass",  # pragma: allowlist secret
                 "DATABASE_SERVICE": "mariadb-service",
@@ -224,10 +216,7 @@ class TestStorageInterfaceEnvVars:
                 attempt_migration=False,
             )
 
-    @pytest.mark.skipif(
-        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
-        reason="mariadb extra not installed",
-    )
+    @pytest.mark.skipif(not HAS_MARIADB, reason="mariadb extra not installed")
     @patch("src.service.data.storage.maria.maria.MariaDBStorage")
     def test_mariadb_credentials_fallback_priority(
         self, mock_storage: MagicMock
@@ -269,10 +258,7 @@ class TestStorageInterfaceEnvVars:
         ):
             get_storage_interface()
 
-    @pytest.mark.skipif(
-        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
-        reason="mariadb extra not installed",
-    )
+    @pytest.mark.skipif(not HAS_MARIADB, reason="mariadb extra not installed")
     def test_mariadb_missing_all_parameters(self) -> None:
         """Test that missing all MariaDB parameters raises ValueError."""
         with (
@@ -292,10 +278,7 @@ class TestStorageInterfaceEnvVars:
         ):
             get_storage_interface()
 
-    @pytest.mark.skipif(
-        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
-        reason="mariadb extra not installed",
-    )
+    @pytest.mark.skipif(not HAS_MARIADB, reason="mariadb extra not installed")
     def test_mariadb_missing_username(self) -> None:
         """Test that missing username raises ValueError."""
         with (
@@ -317,10 +300,7 @@ class TestStorageInterfaceEnvVars:
         ):
             get_storage_interface()
 
-    @pytest.mark.skipif(
-        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
-        reason="mariadb extra not installed",
-    )
+    @pytest.mark.skipif(not HAS_MARIADB, reason="mariadb extra not installed")
     def test_mariadb_missing_password(self) -> None:
         """Test that missing password raises ValueError."""
         with (
@@ -342,10 +322,7 @@ class TestStorageInterfaceEnvVars:
         ):
             get_storage_interface()
 
-    @pytest.mark.skipif(
-        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
-        reason="mariadb extra not installed",
-    )
+    @pytest.mark.skipif(not HAS_MARIADB, reason="mariadb extra not installed")
     def test_mariadb_missing_host(self) -> None:
         """Test that missing host raises ValueError."""
         with (
@@ -367,10 +344,7 @@ class TestStorageInterfaceEnvVars:
         ):
             get_storage_interface()
 
-    @pytest.mark.skipif(
-        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
-        reason="mariadb extra not installed",
-    )
+    @pytest.mark.skipif(not HAS_MARIADB, reason="mariadb extra not installed")
     def test_mariadb_missing_database(self) -> None:
         """Test that missing database raises ValueError."""
         with (
@@ -392,10 +366,7 @@ class TestStorageInterfaceEnvVars:
         ):
             get_storage_interface()
 
-    @pytest.mark.skipif(
-        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
-        reason="mariadb extra not installed",
-    )
+    @pytest.mark.skipif(not HAS_MARIADB, reason="mariadb extra not installed")
     def test_mariadb_missing_multiple_parameters(self) -> None:
         """Test that missing multiple MariaDB parameters raises ValueError with all missing listed."""
         with (

--- a/tests/service/data/test_storage_init.py
+++ b/tests/service/data/test_storage_init.py
@@ -268,3 +268,151 @@ class TestStorageInterfaceEnvVars:
             pytest.raises(ValueError, match="not yet supported"),
         ):
             get_storage_interface()
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
+        reason="mariadb extra not installed",
+    )
+    def test_mariadb_missing_all_parameters(self) -> None:
+        """Test that missing all MariaDB parameters raises ValueError."""
+        with (
+            patch.dict(
+                os.environ,
+                {"SERVICE_STORAGE_FORMAT": "MARIA"},
+                clear=True,
+            ),
+            pytest.raises(
+                ValueError,
+                match="MariaDB storage requires environment variables: "
+                "DATABASE_USERNAME or QUARKUS_DATASOURCE_USERNAME, "
+                "DATABASE_PASSWORD or QUARKUS_DATASOURCE_PASSWORD, "
+                "DATABASE_HOST or DATABASE_SERVICE, "
+                "DATABASE_DATABASE or DATABASE_NAME",
+            ),
+        ):
+            get_storage_interface()
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
+        reason="mariadb extra not installed",
+    )
+    def test_mariadb_missing_username(self) -> None:
+        """Test that missing username raises ValueError."""
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "SERVICE_STORAGE_FORMAT": "MARIA",
+                    "DATABASE_PASSWORD": "test_pass",  # pragma: allowlist secret
+                    "DATABASE_HOST": "localhost",
+                    "DATABASE_DATABASE": "test_db",
+                },
+                clear=True,
+            ),
+            pytest.raises(
+                ValueError,
+                match="MariaDB storage requires environment variables: "
+                "DATABASE_USERNAME or QUARKUS_DATASOURCE_USERNAME",
+            ),
+        ):
+            get_storage_interface()
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
+        reason="mariadb extra not installed",
+    )
+    def test_mariadb_missing_password(self) -> None:
+        """Test that missing password raises ValueError."""
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "SERVICE_STORAGE_FORMAT": "MARIA",
+                    "DATABASE_USERNAME": "test_user",
+                    "DATABASE_HOST": "localhost",
+                    "DATABASE_DATABASE": "test_db",
+                },
+                clear=True,
+            ),
+            pytest.raises(
+                ValueError,
+                match="MariaDB storage requires environment variables: "
+                "DATABASE_PASSWORD or QUARKUS_DATASOURCE_PASSWORD",
+            ),
+        ):
+            get_storage_interface()
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
+        reason="mariadb extra not installed",
+    )
+    def test_mariadb_missing_host(self) -> None:
+        """Test that missing host raises ValueError."""
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "SERVICE_STORAGE_FORMAT": "MARIA",
+                    "DATABASE_USERNAME": "test_user",
+                    "DATABASE_PASSWORD": "test_pass",  # pragma: allowlist secret
+                    "DATABASE_DATABASE": "test_db",
+                },
+                clear=True,
+            ),
+            pytest.raises(
+                ValueError,
+                match="MariaDB storage requires environment variables: "
+                "DATABASE_HOST or DATABASE_SERVICE",
+            ),
+        ):
+            get_storage_interface()
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
+        reason="mariadb extra not installed",
+    )
+    def test_mariadb_missing_database(self) -> None:
+        """Test that missing database raises ValueError."""
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "SERVICE_STORAGE_FORMAT": "MARIA",
+                    "DATABASE_USERNAME": "test_user",
+                    "DATABASE_PASSWORD": "test_pass",  # pragma: allowlist secret
+                    "DATABASE_HOST": "localhost",
+                },
+                clear=True,
+            ),
+            pytest.raises(
+                ValueError,
+                match="MariaDB storage requires environment variables: "
+                "DATABASE_DATABASE or DATABASE_NAME",
+            ),
+        ):
+            get_storage_interface()
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
+        reason="mariadb extra not installed",
+    )
+    def test_mariadb_missing_multiple_parameters(self) -> None:
+        """Test that missing multiple MariaDB parameters raises ValueError with all missing listed."""
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "SERVICE_STORAGE_FORMAT": "MARIA",
+                    "DATABASE_USERNAME": "test_user",
+                    "DATABASE_HOST": "localhost",
+                },
+                clear=True,
+            ),
+            pytest.raises(
+                ValueError,
+                match="MariaDB storage requires environment variables: "
+                "DATABASE_PASSWORD or QUARKUS_DATASOURCE_PASSWORD, "
+                "DATABASE_DATABASE or DATABASE_NAME",
+            ),
+        ):
+            get_storage_interface()

--- a/tests/service/data/test_storage_init.py
+++ b/tests/service/data/test_storage_init.py
@@ -1,0 +1,270 @@
+"""Tests for storage interface initialization with environment variables."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.service.data.storage import get_storage_interface
+from src.service.data.storage.pvc import PVCStorage
+
+# Test constants
+DEFAULT_MARIADB_PORT = 3306
+ALTERNATE_MARIADB_PORT = 3307
+
+
+class TestStorageInterfaceEnvVars:
+    """Test storage interface creation with different environment variable conventions."""
+
+    def test_pvc_storage_creation(self) -> None:
+        """Test PVC storage interface creation."""
+        with patch.dict(
+            os.environ,
+            {
+                "SERVICE_STORAGE_FORMAT": "PVC",
+                "STORAGE_DATA_FOLDER": "/tmp/test",  # noqa: S108
+                "STORAGE_DATA_FILENAME": "test.hdf5",
+            },
+            clear=False,
+        ):
+            storage = get_storage_interface()
+            assert isinstance(storage, PVCStorage)
+            assert storage.data_directory == "/tmp/test"  # noqa: S108
+            assert storage.data_file == "test.hdf5"
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
+        reason="mariadb extra not installed",
+    )
+    @patch("src.service.data.storage.maria.maria.MariaDBStorage")
+    def test_mariadb_with_database_host_and_database(
+        self, mock_storage: MagicMock
+    ) -> None:
+        """Test MariaDB with DATABASE_HOST and DATABASE_DATABASE (direct deployment)."""
+        with patch.dict(
+            os.environ,
+            {
+                "SERVICE_STORAGE_FORMAT": "MARIA",
+                "DATABASE_USERNAME": "test_user",
+                "DATABASE_PASSWORD": "test_pass",  # pragma: allowlist secret
+                "DATABASE_HOST": "localhost",
+                "DATABASE_PORT": str(DEFAULT_MARIADB_PORT),
+                "DATABASE_DATABASE": "test_db",
+                "DATABASE_ATTEMPT_MIGRATION": "0",
+            },
+            clear=False,
+        ):
+            get_storage_interface()
+            # Verify MariaDBStorage was called with correct env vars
+            mock_storage.assert_called_once_with(
+                user="test_user",
+                password="test_pass",  # noqa: S106  # pragma: allowlist secret
+                host="localhost",
+                port=DEFAULT_MARIADB_PORT,
+                database="test_db",
+                attempt_migration=False,
+            )
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
+        reason="mariadb extra not installed",
+    )
+    @patch("src.service.data.storage.maria.maria.MariaDBStorage")
+    def test_mariadb_with_database_service_and_name(
+        self, mock_storage: MagicMock
+    ) -> None:
+        """Test MariaDB with DATABASE_SERVICE and DATABASE_NAME (operator deployment)."""
+        with patch.dict(
+            os.environ,
+            {
+                "SERVICE_STORAGE_FORMAT": "MARIA",
+                "DATABASE_USERNAME": "operator_user",
+                "DATABASE_PASSWORD": "operator_pass",  # pragma: allowlist secret
+                "DATABASE_SERVICE": "mariadb-service",
+                "DATABASE_PORT": str(ALTERNATE_MARIADB_PORT),
+                "DATABASE_NAME": "operator_db",
+                "DATABASE_ATTEMPT_MIGRATION": "false",
+            },
+            clear=False,
+        ):
+            get_storage_interface()
+            # Verify MariaDBStorage was called with operator env vars
+            mock_storage.assert_called_once_with(
+                user="operator_user",
+                password="operator_pass",  # noqa: S106  # pragma: allowlist secret
+                host="mariadb-service",
+                port=ALTERNATE_MARIADB_PORT,
+                database="operator_db",
+                attempt_migration=False,
+            )
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
+        reason="mariadb extra not installed",
+    )
+    @patch("src.service.data.storage.maria.maria.MariaDBStorage")
+    def test_mariadb_fallback_priority(self, mock_storage: MagicMock) -> None:
+        """Test that DATABASE_HOST takes priority over DATABASE_SERVICE when both present."""
+        with patch.dict(
+            os.environ,
+            {
+                "SERVICE_STORAGE_FORMAT": "MARIA",
+                "DATABASE_USERNAME": "test_user",
+                "DATABASE_PASSWORD": "test_pass",  # pragma: allowlist secret
+                "DATABASE_HOST": "direct_host",
+                "DATABASE_SERVICE": "operator_host",
+                "DATABASE_DATABASE": "direct_db",
+                "DATABASE_NAME": "operator_db",
+                "DATABASE_PORT": str(DEFAULT_MARIADB_PORT),
+                "DATABASE_ATTEMPT_MIGRATION": "0",
+            },
+            clear=False,
+        ):
+            get_storage_interface()
+            # Verify DATABASE_HOST and DATABASE_DATABASE take priority
+            mock_storage.assert_called_once_with(
+                user="test_user",
+                password="test_pass",  # noqa: S106  # pragma: allowlist secret
+                host="direct_host",
+                port=DEFAULT_MARIADB_PORT,
+                database="direct_db",
+                attempt_migration=False,
+            )
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
+        reason="mariadb extra not installed",
+    )
+    @patch("src.service.data.storage.maria.maria.MariaDBStorage")
+    def test_mariadb_mixed_conventions(self, mock_storage: MagicMock) -> None:
+        """Test MariaDB with mixed env var conventions (DATABASE_HOST + DATABASE_NAME)."""
+        with patch.dict(
+            os.environ,
+            {
+                "SERVICE_STORAGE_FORMAT": "MARIA",
+                "DATABASE_USERNAME": "test_user",
+                "DATABASE_PASSWORD": "test_pass",  # pragma: allowlist secret
+                "DATABASE_HOST": "mixed_host",
+                "DATABASE_NAME": "mixed_db",
+                "DATABASE_PORT": str(DEFAULT_MARIADB_PORT),
+                "DATABASE_ATTEMPT_MIGRATION": "0",
+            },
+            clear=False,
+        ):
+            get_storage_interface()
+            # Verify mixed conventions work
+            mock_storage.assert_called_once_with(
+                user="test_user",
+                password="test_pass",  # noqa: S106  # pragma: allowlist secret
+                host="mixed_host",
+                port=DEFAULT_MARIADB_PORT,
+                database="mixed_db",
+                attempt_migration=False,
+            )
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
+        reason="mariadb extra not installed",
+    )
+    @patch("src.service.data.storage.maria.maria.MariaDBStorage")
+    def test_mariadb_with_database_format(self, mock_storage: MagicMock) -> None:
+        """Test MariaDB with SERVICE_STORAGE_FORMAT=DATABASE (operator convention)."""
+        with patch.dict(
+            os.environ,
+            {
+                "SERVICE_STORAGE_FORMAT": "DATABASE",
+                "DATABASE_USERNAME": "operator_user",
+                "DATABASE_PASSWORD": "operator_pass",  # pragma: allowlist secret
+                "DATABASE_SERVICE": "mariadb-service",
+                "DATABASE_PORT": str(DEFAULT_MARIADB_PORT),
+                "DATABASE_NAME": "operator_db",
+                "DATABASE_ATTEMPT_MIGRATION": "0",
+            },
+            clear=False,
+        ):
+            get_storage_interface()
+            # Verify DATABASE storage format works (operator convention)
+            mock_storage.assert_called_once_with(
+                user="operator_user",
+                password="operator_pass",  # noqa: S106  # pragma: allowlist secret
+                host="mariadb-service",
+                port=DEFAULT_MARIADB_PORT,
+                database="operator_db",
+                attempt_migration=False,
+            )
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
+        reason="mariadb extra not installed",
+    )
+    @patch("src.service.data.storage.maria.maria.MariaDBStorage")
+    def test_mariadb_with_quarkus_credentials(self, mock_storage: MagicMock) -> None:
+        """Test MariaDB with QUARKUS_DATASOURCE_USERNAME/PASSWORD (operator convention)."""
+        with patch.dict(
+            os.environ,
+            {
+                "SERVICE_STORAGE_FORMAT": "DATABASE",
+                "QUARKUS_DATASOURCE_USERNAME": "quarkus_user",
+                "QUARKUS_DATASOURCE_PASSWORD": "quarkus_pass",  # pragma: allowlist secret
+                "DATABASE_SERVICE": "mariadb-service",
+                "DATABASE_PORT": str(DEFAULT_MARIADB_PORT),
+                "DATABASE_NAME": "operator_db",
+                "DATABASE_ATTEMPT_MIGRATION": "0",
+            },
+            clear=False,
+        ):
+            get_storage_interface()
+            # Verify QUARKUS_DATASOURCE_* env vars work
+            mock_storage.assert_called_once_with(
+                user="quarkus_user",
+                password="quarkus_pass",  # noqa: S106  # pragma: allowlist secret
+                host="mariadb-service",
+                port=DEFAULT_MARIADB_PORT,
+                database="operator_db",
+                attempt_migration=False,
+            )
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("mariadb", reason="mariadb extra not installed"),
+        reason="mariadb extra not installed",
+    )
+    @patch("src.service.data.storage.maria.maria.MariaDBStorage")
+    def test_mariadb_credentials_fallback_priority(
+        self, mock_storage: MagicMock
+    ) -> None:
+        """Test that DATABASE_USERNAME/PASSWORD take priority over QUARKUS_DATASOURCE_*."""
+        with patch.dict(
+            os.environ,
+            {
+                "SERVICE_STORAGE_FORMAT": "MARIA",
+                "DATABASE_USERNAME": "direct_user",
+                "QUARKUS_DATASOURCE_USERNAME": "quarkus_user",
+                "DATABASE_PASSWORD": "direct_pass",  # pragma: allowlist secret
+                "QUARKUS_DATASOURCE_PASSWORD": "quarkus_pass",  # pragma: allowlist secret
+                "DATABASE_HOST": "localhost",
+                "DATABASE_PORT": str(DEFAULT_MARIADB_PORT),
+                "DATABASE_DATABASE": "test_db",
+                "DATABASE_ATTEMPT_MIGRATION": "0",
+            },
+            clear=False,
+        ):
+            get_storage_interface()
+            # Verify DATABASE_USERNAME/PASSWORD take priority
+            mock_storage.assert_called_once_with(
+                user="direct_user",
+                password="direct_pass",  # noqa: S106  # pragma: allowlist secret
+                host="localhost",
+                port=DEFAULT_MARIADB_PORT,
+                database="test_db",
+                attempt_migration=False,
+            )
+
+    def test_unsupported_storage_format(self) -> None:
+        """Test that unsupported storage format raises ValueError."""
+        with (
+            patch.dict(
+                os.environ, {"SERVICE_STORAGE_FORMAT": "UNSUPPORTED"}, clear=False
+            ),
+            pytest.raises(ValueError, match="not yet supported"),
+        ):
+            get_storage_interface()


### PR DESCRIPTION
## Problem

The TrustyAI Python service cannot connect to MariaDB when deployed via the operator due to incompatible environment variable conventions.

**Root cause:** The operator and service use different naming conventions for the same configuration values:

| Configuration | Operator Sets | Service Reads | Result |
|--------------|---------------|---------------|---------|
| Storage backend type | `SERVICE_STORAGE_FORMAT=DATABASE` | Checks for `MARIA` only | ❌ Rejected as "unsupported" |
| Username | `QUARKUS_DATASOURCE_USERNAME` | Reads `DATABASE_USERNAME` | ❌ Gets `None` |
| Password | `QUARKUS_DATASOURCE_PASSWORD` | Reads `DATABASE_PASSWORD` | ❌ Gets `None` |
| Database hostname | `DATABASE_SERVICE` | Reads `DATABASE_HOST` | ❌ Gets `None` |
| Database name | `DATABASE_NAME` | Reads `DATABASE_DATABASE` | ❌ Gets `None` |

**Impact:** Service fails with `ValueError: Storage format=DATABASE not yet supported` or `DBConnectionError`.

## Solution

Make the service accept **both** naming conventions with fallback logic:

**Storage format compatibility:**
```python
# Accept both "MARIA" (direct deployment) and "DATABASE" (operator)
if storage_format in ("MARIA", "DATABASE"):
```

**Environment variable fallbacks:**
```python
# Try direct deployment vars first, fall back to operator vars
user = os.environ.get("DATABASE_USERNAME") or os.environ.get("QUARKUS_DATASOURCE_USERNAME")
password = os.environ.get("DATABASE_PASSWORD") or os.environ.get("QUARKUS_DATASOURCE_PASSWORD")
host = os.environ.get("DATABASE_HOST") or os.environ.get("DATABASE_SERVICE")
database = os.environ.get("DATABASE_DATABASE") or os.environ.get("DATABASE_NAME")
```

This maintains backward compatibility with direct deployments while supporting operator deployments.

## Testing

9 tests covering all deployment scenarios:

- PVC storage (baseline)
- MariaDB with direct deployment vars (`DATABASE_USERNAME`, `DATABASE_PASSWORD`, `DATABASE_HOST`, `DATABASE_DATABASE`)
- MariaDB with operator vars (`QUARKUS_DATASOURCE_USERNAME`, `QUARKUS_DATASOURCE_PASSWORD`, `DATABASE_SERVICE`, `DATABASE_NAME`)
- MariaDB with operator storage format (`SERVICE_STORAGE_FORMAT=DATABASE`)
- Fallback priority for host/database when both conventions present
- Fallback priority for username/password when both conventions present
- Mixed conventions (one direct var, one operator var)
- Error handling for unsupported formats

```bash
uv run pytest tests/service/data/test_storage_init.py -v
# 9 passed in 14.26s
```

**Coverage:** 77% for `src/service/data/storage/__init__.py` - all new fallback logic fully tested.

All tests use mocking to avoid requiring actual database connections.

## Files Changed

- `src/service/data/storage/__init__.py` — Storage format + env var compatibility
- `tests/service/data/test_storage_init.py` — Comprehensive test coverage (new file)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage selection now recognizes both MariaDB formats and accepts multiple environment-variable conventions with defined precedence; port parsing remains numeric.
  * Improved validation: missing database parameters produce clear error messages listing what's absent.

* **Tests**
  * Added comprehensive tests for storage initialization covering PVC and MariaDB scenarios, env-var conventions, precedence rules, and validation error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->