### PR TITLE
fix(consumer): flatten InferencePartialPayload to match Java wire format

### DIFF
--- a/src/endpoints/consumer/__init__.py
+++ b/src/endpoints/consumer/__init__.py
@@ -4,69 +4,22 @@ from enum import StrEnum
 from typing import Any, Literal
 
 import numpy as np
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 PartialKind = Literal["request", "response"]
 
 
-class PartialPayloadId(BaseModel):
-    """Identifier for partial inference payloads."""
-
-    prediction_id: str | None = None
-    kind: PartialKind | None = None
-
-    def get_prediction_id(self) -> str | None:
-        """Get prediction ID."""
-        return self.prediction_id
-
-    def set_prediction_id(self, id_: str) -> None:
-        """Set prediction ID."""
-        self.prediction_id = id_
-
-    def get_kind(self) -> PartialKind | None:
-        """Get payload kind (request or response)."""
-        return self.kind
-
-    def set_kind(self, kind: PartialKind) -> None:
-        """Set payload kind (request or response)."""
-        self.kind = kind
-
-
 class InferencePartialPayload(BaseModel):
-    """Partial inference payload for KServe agent uploads."""
+    """Partial inference payload for KServe agent uploads.
 
-    partialPayloadId: PartialPayloadId | None = None
-    metadata: dict[str, str] | None = {}
+    Flat structure matching the Java TrustyAI service wire format.
+    """
+
+    id: str | None = None
+    kind: PartialKind | None = None
+    metadata: dict[str, str] = Field(default_factory=dict)
     data: str | None = None
     modelid: str | None = None
-
-    def get_id(self) -> str | None:
-        """Get prediction ID from partial payload."""
-        return self.partialPayloadId.prediction_id if self.partialPayloadId else None
-
-    def set_id(self, id_: str) -> None:
-        """Set prediction ID on partial payload."""
-        if not self.partialPayloadId:
-            self.partialPayloadId = PartialPayloadId()
-        self.partialPayloadId.prediction_id = id_
-
-    def get_kind(self) -> PartialKind | None:
-        """Get payload kind (request or response)."""
-        return self.partialPayloadId.kind if self.partialPayloadId else None
-
-    def set_kind(self, kind: PartialKind) -> None:
-        """Set payload kind (request or response)."""
-        if not self.partialPayloadId:
-            self.partialPayloadId = PartialPayloadId()
-        self.partialPayloadId.kind = kind
-
-    def get_model_id(self) -> str | None:
-        """Get model ID."""
-        return self.modelid
-
-    def set_model_id(self, model_id: str) -> None:
-        """Set model ID."""
-        self.modelid = model_id
 
 
 class KServeDataType(StrEnum):

--- a/src/endpoints/consumer/consumer_endpoint.py
+++ b/src/endpoints/consumer/consumer_endpoint.py
@@ -82,38 +82,22 @@ async def consume_inference_payload(
     """
     storage_interface = get_global_storage_interface()
 
-    # Validate payload fields before entering try block
-    if not payload.modelid:
-        raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail="Payload requires 'modelid' field",
-        )
-
-    payload_id = payload.get_id()
-    payload_kind = payload.get_kind()
-    model_id = payload.get_model_id()
-
-    if not payload_id:
+    # Validate required fields before processing
+    if not payload.id:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST, detail="Payload requires 'id' field"
         )
 
-    if not model_id:
-        raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail="Payload requires 'modelid' field",
-        )
-
-    if not payload_kind:
+    if not payload.kind:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,
             detail="Payload must specify 'kind' as either 'request' or 'response'",
         )
 
-    if payload_kind not in ("request", "response"):
+    if not payload.modelid:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,
-            detail=f"Unsupported payload kind={payload_kind}",
+            detail="Payload requires 'modelid' field",
         )
 
     if not payload.data:
@@ -124,11 +108,11 @@ async def consume_inference_payload(
 
     try:
         partial_payload = PartialPayload(data=payload.data)
-        if payload_kind == "request":
+        if payload.kind == "request":
             logger.info(
                 "Received partial input payload from model=%s, id=%s",
-                model_id,
-                payload_id,
+                payload.modelid,
+                payload.id,
             )
 
             try:
@@ -143,24 +127,24 @@ async def consume_inference_payload(
 
             # Store the input payload
             await storage_interface.persist_partial_payload(
-                partial_payload, payload_id=payload_id, is_input=is_input
+                partial_payload, payload_id=payload.id, is_input=is_input
             )
 
             output_payload = await storage_interface.get_partial_payload(
-                payload_id, is_input=False, is_modelmesh=True
+                payload.id, is_input=False, is_modelmesh=True
             )
 
             if output_payload:
                 _validate_payload_type(output_payload, PartialPayload)
                 await reconcile_modelmesh_payloads(
-                    partial_payload, output_payload, payload_id, model_id
+                    partial_payload, output_payload, payload.id, payload.modelid
                 )
 
-        elif payload_kind == "response":
+        elif payload.kind == "response":
             logger.info(
                 "Received partial output payload from model=%s, id=%s",
-                model_id,
-                payload_id,
+                payload.modelid,
+                payload.id,
             )
 
             try:
@@ -175,18 +159,18 @@ async def consume_inference_payload(
 
             # Store the output payload
             await storage_interface.persist_partial_payload(
-                payload=partial_payload, payload_id=payload_id, is_input=is_input
+                payload=partial_payload, payload_id=payload.id, is_input=is_input
             )
 
             input_payload = await storage_interface.get_partial_payload(
-                payload_id, is_input=True, is_modelmesh=True
+                payload.id, is_input=True, is_modelmesh=True
             )
 
             if input_payload:
                 # We have both input and output. Reconcile them
                 _validate_payload_type(input_payload, PartialPayload)
                 await reconcile_modelmesh_payloads(
-                    input_payload, partial_payload, payload_id, model_id
+                    input_payload, partial_payload, payload.id, payload.modelid
                 )
     except HTTPException:
         # HTTPException always goes through
@@ -202,7 +186,7 @@ async def consume_inference_payload(
     else:
         return {
             "status": "success",
-            "message": f"Payload for {payload_id} processed successfully",
+            "message": f"Payload for {payload.id} processed successfully",
         }
 
 

--- a/tests/service/test_consumer_endpoint_reconciliation.py
+++ b/tests/service/test_consumer_endpoint_reconciliation.py
@@ -104,7 +104,8 @@ class TestConsumerEndpointReconciliation(unittest.TestCase):
         inference_payload = {
             "data": self.input_payload.data,
             "modelid": self.model_name,
-            "partialPayloadId": {"prediction_id": self.request_id, "kind": "request"},
+            "id": self.request_id,
+            "kind": "request",
         }
 
         response = self.client.post("/consumer/kserve/v2", json=inference_payload)
@@ -130,7 +131,8 @@ class TestConsumerEndpointReconciliation(unittest.TestCase):
         inference_payload = {
             "data": self.output_payload.data,
             "modelid": self.model_name,
-            "partialPayloadId": {"prediction_id": self.request_id, "kind": "response"},
+            "id": self.request_id,
+            "kind": "response",
         }
 
         response = self.client.post("/consumer/kserve/v2", json=inference_payload)
@@ -189,10 +191,8 @@ class TestConsumerEndpointReconciliation(unittest.TestCase):
             input_inference_payload = {
                 "data": self.input_payload.data,
                 "modelid": self.model_name,
-                "partialPayloadId": {
-                    "prediction_id": self.request_id,
-                    "kind": "request",
-                },
+                "id": self.request_id,
+                "kind": "request",
             }
 
             response_input = self.client.post(
@@ -220,10 +220,8 @@ class TestConsumerEndpointReconciliation(unittest.TestCase):
             output_inference_payload = {
                 "data": self.output_payload.data,
                 "modelid": self.model_name,
-                "partialPayloadId": {
-                    "prediction_id": self.request_id,
-                    "kind": "response",
-                },
+                "id": self.request_id,
+                "kind": "response",
             }
 
             response_output = self.client.post(
@@ -266,6 +264,82 @@ TestConsumerEndpointReconciliation.test_consume_output_payload = lambda self: ( 
 TestConsumerEndpointReconciliation.test_reconcile_payloads = lambda self: (  # type: ignore[attr-defined]
     run_async_test(self._test_reconcile_payloads())
 )
+
+
+class TestConsumerEndpointValidation(unittest.TestCase):
+    """Test validation of required fields and invalid values on the consumer endpoint."""
+
+    def setUp(self) -> None:
+        """Set up test client with mocked storage."""
+        self.storage_patch = mock.patch(
+            "src.endpoints.consumer.consumer_endpoint.get_global_storage_interface",
+        )
+        self.mock_get_storage = self.storage_patch.start()
+        self.mock_get_storage.return_value = mock.AsyncMock()
+
+        self.app = FastAPI()
+        self.app.include_router(consumer_router)
+        self.client = TestClient(self.app, raise_server_exceptions=False)
+
+        self.valid_payload = {
+            "id": "test-id",
+            "kind": "request",
+            "modelid": "test-model",
+            "data": "dGVzdA==",
+        }
+
+    def tearDown(self) -> None:
+        """Clean up patches."""
+        self.storage_patch.stop()
+
+    def test_missing_id_returns_400(self) -> None:
+        """Payload without 'id' field is rejected with 400."""
+        payload = {**self.valid_payload}
+        del payload["id"]
+        response = self.client.post("/consumer/kserve/v2", json=payload)
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert "id" in response.json()["detail"]
+
+    def test_missing_kind_returns_400(self) -> None:
+        """Payload without 'kind' field is rejected with 400."""
+        payload = {**self.valid_payload}
+        del payload["kind"]
+        response = self.client.post("/consumer/kserve/v2", json=payload)
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert "kind" in response.json()["detail"]
+
+    def test_missing_modelid_returns_400(self) -> None:
+        """Payload without 'modelid' field is rejected with 400."""
+        payload = {**self.valid_payload}
+        del payload["modelid"]
+        response = self.client.post("/consumer/kserve/v2", json=payload)
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert "modelid" in response.json()["detail"]
+
+    def test_missing_data_returns_400(self) -> None:
+        """Payload without 'data' field is rejected with 400."""
+        payload = {**self.valid_payload}
+        del payload["data"]
+        response = self.client.post("/consumer/kserve/v2", json=payload)
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert "data" in response.json()["detail"]
+
+    def test_invalid_kind_returns_422(self) -> None:
+        """Invalid kind value is rejected by Pydantic with 422."""
+        payload = {**self.valid_payload, "kind": "prediction"}
+        response = self.client.post("/consumer/kserve/v2", json=payload)
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+    def test_nested_format_returns_400(self) -> None:
+        """Old nested format should fail — partialPayloadId is ignored, id is null."""
+        payload = {
+            "partialPayloadId": {"prediction_id": "test-id", "kind": "request"},
+            "modelid": "test-model",
+            "data": "dGVzdA==",
+        }
+        response = self.client.post("/consumer/kserve/v2", json=payload)
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert "id" in response.json()["detail"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The `/consumer/kserve/v2` endpoint silently rejects **all** inference payloads from KServe's inference logger because the Python `InferencePartialPayload` model expects a nested format that does not match the flat wire format sent by KServe.

## Root cause

The Python service modeled the Java **class hierarchy** rather than the **wire format**.

The Java `InferencePartialPayload` class has a nested `PartialPayloadId` object internally, but Jackson serializes it as **flat JSON** on the wire:

```json
{"id": "abc-123", "kind": "request", "modelid": "gaussian-credit-model", "data": "CgdleGFt..."}
```

The Python Pydantic model reproduced the internal Java structure with an explicit nested `partialPayloadId` wrapper, expecting:

```json
{
  "partialPayloadId": {"prediction_id": "abc-123", "kind": "request"},
  "modelid": "gaussian-credit-model",
  "data": "CgdleGFt..."
}
```

Because Pydantic silently ignores unknown fields by default, the flat `id` and `kind` fields from KServe were discarded, `partialPayloadId` defaulted to `None`, and every payload was rejected at the null-check — with no error logged.

**Downstream impact:** Integration tests (e.g. `test_drift_send_inference[pvc-storage]`) timeout at 300s waiting for observations that never arrive, since no payloads are ever successfully ingested.

## The fix

- **Delete** the `PartialPayloadId` wrapper class entirely
- **Flatten** `InferencePartialPayload` to use direct `id`, `kind`, `modelid`, `data` fields matching the Java wire format
- **Remove** getter/setter methods — replaced by direct attribute access
- **Remove** redundant runtime validation (duplicate `modelid` check, unreachable `kind not in (...)` guard) — Pydantic's `Literal["request", "response"]` type handles `kind` validation at deserialization time (returns 422 for invalid values)
- **Fix** `metadata` field type from `dict[str, str] | None = {}` (mutable default + nullable) to `dict[str, str] = Field(default_factory=dict)` (safe default, non-nullable)

## Files changed

| File | Change |
|------|--------|
| `src/endpoints/consumer/__init__.py` | Delete `PartialPayloadId`, flatten `InferencePartialPayload`, remove getters/setters |
| `src/endpoints/consumer/consumer_endpoint.py` | Direct field access, remove redundant validation |
| `tests/service/test_consumer_endpoint_reconciliation.py` | Update 4 test payloads to flat format, add 6 negative validation tests |

## Test plan

- [x] All 9 consumer endpoint tests pass (3 reconciliation + 6 new validation)
- [x] Validation tests cover: missing `id`, missing `kind`, missing `modelid`, missing `data`, invalid `kind` value (422), old nested format rejected (400)
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `pyrefly check` clean
- [x] Rebuild container image and run `test_drift_send_inference` integration test against live KServe deployment

🤖 Generated with [Claude Code](https://claude.ai/claude-code)