### PR TITLE
fix(consumer): accept flat KServe tensors by validating element count

### DIFF
--- a/src/endpoints/consumer/__init__.py
+++ b/src/endpoints/consumer/__init__.py
@@ -126,13 +126,13 @@ class KServeData(BaseModel):
     @model_validator(mode="after")
     def _validate_shape(self) -> "KServeData":
         raw = np.array(self.data, dtype=object)
-        actual = tuple(raw.shape)
         declared = tuple(self.shape)
-        if declared != actual:
-            msg = f"Declared shape {declared} does not match data shape {actual}"
-            raise ValueError(
-                msg,
-            )
+        expected_elements = int(np.prod(declared))
+        actual_elements = raw.size
+        if expected_elements != actual_elements:
+            msg = f"Declared shape {declared} requires {expected_elements} elements but got {actual_elements}"
+            raise ValueError(msg)
+        self.data = raw.reshape(declared).tolist()
         return self
 
     @model_validator(mode="after")

--- a/tests/endpoints/consumer/__init__.py
+++ b/tests/endpoints/consumer/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for consumer endpoint validation."""

--- a/tests/endpoints/consumer/test_kserve_data_validation.py
+++ b/tests/endpoints/consumer/test_kserve_data_validation.py
@@ -1,0 +1,125 @@
+"""Tests for KServeData shape and datatype validation."""
+
+import unittest
+
+import pytest
+
+from src.endpoints.consumer import KServeData
+
+
+class TestKServeDataShapeValidation(unittest.TestCase):
+    """Test that _validate_shape accepts flat tensors and reshapes them."""
+
+    def test_flat_data_reshaped_to_column_vector(self) -> None:
+        """Flat list with shape [5, 1] is reshaped to column vector."""
+        tensor = KServeData(
+            name="output",
+            shape=[5, 1],
+            datatype="FP32",
+            data=[0.1, 0.2, 0.3, 0.4, 0.5],
+        )
+        assert tensor.data == [[0.1], [0.2], [0.3], [0.4], [0.5]]
+
+    def test_flat_data_reshaped_to_matrix(self) -> None:
+        """Flat list with shape [2, 3] is reshaped to 2x3 matrix."""
+        tensor = KServeData(
+            name="output",
+            shape=[2, 3],
+            datatype="INT32",
+            data=[1, 2, 3, 4, 5, 6],
+        )
+        assert tensor.data == [[1, 2, 3], [4, 5, 6]]
+
+    def test_already_shaped_data_unchanged(self) -> None:
+        """Pre-shaped data matching declared shape passes unchanged."""
+        tensor = KServeData(
+            name="output",
+            shape=[2, 3],
+            datatype="INT32",
+            data=[[1, 2, 3], [4, 5, 6]],
+        )
+        assert tensor.data == [[1, 2, 3], [4, 5, 6]]
+
+    def test_scalar_shape(self) -> None:
+        """Single-element tensor with shape [1] passes."""
+        tensor = KServeData(
+            name="output",
+            shape=[1],
+            datatype="FP32",
+            data=[42.0],
+        )
+        assert tensor.data == [42.0]
+
+    def test_1d_vector(self) -> None:
+        """1D vector with shape [5] passes without reshape."""
+        tensor = KServeData(
+            name="output",
+            shape=[5],
+            datatype="FP32",
+            data=[1.0, 2.0, 3.0, 4.0, 5.0],
+        )
+        assert tensor.data == [1.0, 2.0, 3.0, 4.0, 5.0]
+
+    def test_wrong_element_count_raises(self) -> None:
+        """Mismatched element count raises ValueError."""
+        with pytest.raises(ValueError, match=r"requires 5 elements but got 3"):
+            KServeData(
+                name="output",
+                shape=[5, 1],
+                datatype="FP32",
+                data=[1.0, 2.0, 3.0],
+            )
+
+    def test_3d_flat_data_reshaped(self) -> None:
+        """Flat list reshaped to 3D tensor."""
+        tensor = KServeData(
+            name="output",
+            shape=[2, 2, 2],
+            datatype="INT32",
+            data=[1, 2, 3, 4, 5, 6, 7, 8],
+        )
+        assert tensor.data == [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
+
+    def test_empty_tensor(self) -> None:
+        """Zero-element tensor with shape [0] and empty data passes."""
+        tensor = KServeData(
+            name="output",
+            shape=[0],
+            datatype="FP32",
+            data=[],
+        )
+        assert tensor.data == []
+
+    def test_empty_shape_with_data_raises(self) -> None:
+        """Zero-element shape with non-empty data raises ValueError."""
+        with pytest.raises(ValueError, match=r"requires 0 elements but got 1"):
+            KServeData(
+                name="output",
+                shape=[0],
+                datatype="FP32",
+                data=[1.0],
+            )
+
+    def test_flat_reshape_then_type_validation_unsigned(self) -> None:
+        """Flat data is reshaped before type validation catches negative unsigned values."""
+        with pytest.raises(ValueError, match=r"Negative value"):
+            KServeData(
+                name="output",
+                shape=[2, 2],
+                datatype="UINT32",
+                data=[1, 2, -3, 4],
+            )
+
+    def test_flat_reshape_then_type_validation_passes(self) -> None:
+        """Flat data is reshaped and then passes type validation end-to-end."""
+        tensor = KServeData(
+            name="output",
+            shape=[2, 2],
+            datatype="UINT32",
+            data=[1, 2, 3, 4],
+        )
+        assert tensor.data == [[1, 2], [3, 4]]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`KServeData._validate_shape` rejects valid KServe V2 inference payloads where data is flat (row-major flattened), which is the standard format from model servers like mlserver, vLLM, and Triton. This prevents output payloads from being accepted, blocking reconciliation and causing integration test timeouts.

## Root cause

The validator compares `np.array(data).shape` against the declared `shape` field using strict equality. Model servers commonly return flat data with a separate shape field for reshaping:

```json
{"name": "predict", "shape": [5, 1], "datatype": "FP32",
 "data": [0.166, 0.256, 0.060, 0.223, 0.196]}
```

- Declared shape: `(5, 1)` — 5 elements
- `np.array([0.166, ...]).shape` — `(5,)` (flat)
- Validator rejects: `Declared shape (5, 1) does not match data shape (5,)`

The KServe agent logs confirmed this was the actual failure — output payloads returned HTTP 400 while input payloads were accepted with 200. Without both halves, reconciliation never happens, no observations are stored, and integration tests (`test_drift_send_inference`) timeout at 300s.

**Note:** This is distinct from the payload format mismatch fixed in PR #168. The KServe agent in RawDeployment mode sends to the root endpoint (`/`), which uses `KServeInferenceRequest`/`KServeInferenceResponse` models (containing `KServeData` tensors), not the `/consumer/kserve/v2` endpoint's `InferencePartialPayload`.

## The fix

Replace strict shape comparison with **element-count validation** + **in-place reshape**:

- Validate that `np.prod(declared_shape)` equals the number of data elements
- Reshape flat data to the declared shape via `raw.reshape(declared).tolist()`
- Downstream `process_payload()` directly accesses `.data` and trusts it matches the declared shape — reshaping in the validator preserves this contract

The Java TrustyAI service has no shape validation at deserialization, so this aligns behavior. Element count validation still catches genuinely malformed payloads (wrong number of elements).

## Files changed

| File | Change |
|------|--------|
| `src/endpoints/consumer/__init__.py` | Replace strict shape check with element-count + reshape in `_validate_shape` |
| `tests/endpoints/consumer/test_kserve_data_validation.py` | New: 11 tests for shape validation |
| `tests/endpoints/consumer/__init__.py` | New: package init |

## Test plan

- [x] 11 shape validation tests pass — flat→column vector, flat→matrix, flat→3D, already-shaped passthrough, 1D vector, scalar, wrong element count, empty tensor, empty shape with data, validator chain (unsigned rejection + pass)
- [x] Full test suite: 449 passed, 0 failures
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `pyrefly check` clean
- [x] Rebuild container image and run `test_drift_send_inference` integration test against live KServe deployment

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shape validation to handle flattened input arrays by automatically reshaping them based on total element count.

* **Tests**
  * Added comprehensive test coverage for shape validation scenarios, including reshaping behavior, datatype validation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->