### PR TITLE
fix(app): strip trailing slashes to prevent 307 redirects dropping POST bodies

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import os
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from http import HTTPStatus
 from pathlib import Path
@@ -126,6 +126,17 @@ app.add_middleware(
 # Gzip decompression for KServe agent uploads (added last, runs first)
 # This ensures request decompression happens before other middleware
 app.add_middleware(GzipRequestMiddleware)
+
+
+@app.middleware("http")
+async def strip_trailing_slash(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    """Strip trailing slashes to avoid 307 redirects that drop POST bodies."""
+    if request.url.path != "/" and request.url.path.endswith("/"):
+        request.scope["path"] = request.url.path.rstrip("/")
+    return await call_next(request)
+
 
 # Include all routers
 app.include_router(

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -48,6 +48,21 @@ class TestAppCoreEndpoints:
         content = response.text
         assert len(content) > 0
 
+    def test_trailing_slash_no_redirect(self) -> None:
+        """Trailing slash must not 307 redirect (which drops POST bodies)."""
+        response = client.post(
+            "/metrics/drift/kstest/",
+            json={"modelId": "test"},
+        )
+        assert response.status_code != HTTPStatus.TEMPORARY_REDIRECT
+        assert response.status_code != HTTPStatus.NOT_FOUND
+        # Should match the same route as without trailing slash
+        response_no_slash = client.post(
+            "/metrics/drift/kstest",
+            json={"modelId": "test"},
+        )
+        assert response.status_code == response_no_slash.status_code
+
     def test_cors_headers(self) -> None:
         """Test that CORS headers are properly configured."""
         # CORS headers are added by middleware but may not appear in TestClient


### PR DESCRIPTION
## Summary

POST requests with trailing slashes (e.g. `POST /metrics/drift/meanshift/`) trigger FastAPI's default 307 Temporary Redirect to the non-trailing-slash path. The redirect drops the POST body, causing the client to receive an empty response and fail with `JSONDecodeError`.

## Root cause

FastAPI's `redirect_slashes=True` (the default) automatically redirects `/path/` to `/path` via 307. While this works for GET requests, 307 redirects on POST requests cause most HTTP clients to drop the request body on the redirect — the client follows the redirect but sends an empty POST.

Evidence from TrustyAI logs:
```
"POST /metrics/drift/meanshift/ 1.1" 307 0
"POST /metrics/drift/kstest/ 1.1" 307 0
```

The `0` indicates zero bytes in the response body.

## The fix

Add HTTP middleware that strips trailing slashes from the request path before routing, so both `/path` and `/path/` resolve to the same handler without a redirect. The root path (`/`) is excluded.

**Why not `redirect_slashes=False`?** That approach makes trailing-slash paths return 404 instead of 307 — equally broken for clients that send trailing slashes. The middleware approach handles both forms transparently.

## Files changed

| File | Change |
|------|--------|
| `src/main.py` | Add `strip_trailing_slash` middleware, import `Callable`/`Awaitable` |
| `tests/test_app_integration.py` | Add test: POST with trailing slash matches same route without redirect |

## Test plan

- [x] Trailing slash POST returns same status as non-trailing-slash POST (not 307, not 404)
- [x] All 14 app integration tests pass
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `pyrefly check` clean
- [ ] Rebuild container image and verify integration tests no longer get 307 on trailing-slash POST

🤖 Generated with [Claude Code](https://claude.ai/claude-code)