### PR TITLE
fix(app): register missing drift metric routers

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -26,8 +26,15 @@ from src.endpoints.explainers.global_explainer import router as explainers_globa
 from src.endpoints.explainers.local_explainer import router as explainers_local_router
 from src.endpoints.metadata import router as metadata_router
 from src.endpoints.metrics.batch_mean import router as batch_mean_router
+from src.endpoints.metrics.drift.approx_ks_test import (
+    router as drift_approxkstest_router,
+)
 from src.endpoints.metrics.drift.compare_means import (
     router as drift_comparemeans_router,
+)
+from src.endpoints.metrics.drift.fourier_mmd import router as drift_fouriermmd_router
+from src.endpoints.metrics.drift.jensen_shannon import (
+    router as drift_jensenshannon_router,
 )
 from src.endpoints.metrics.drift.kolmogorov_smirnov import router as drift_kstest_router
 from src.endpoints.metrics.fairness.group.dir import router as dir_router
@@ -158,6 +165,18 @@ app.include_router(
     tags=[
         "Drift Metrics: KSTest",
     ],
+)
+app.include_router(
+    drift_fouriermmd_router,
+    tags=["Drift Metrics: FourierMMD"],
+)
+app.include_router(
+    drift_approxkstest_router,
+    tags=["Drift Metrics: ApproxKSTest"],
+)
+app.include_router(
+    drift_jensenshannon_router,
+    tags=["Drift Metrics: JensenShannon"],
 )
 
 app.include_router(explainers_global_router, tags=["Explainers: Global"])

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -230,3 +230,51 @@ class TestCompareMeansMetricIntegration:
 
         meanshift_list = openapi["paths"]["/metrics/drift/meanshift/requests"]["get"]
         assert meanshift_list.get("deprecated") is True
+
+
+class TestFourierMMDMetricIntegration:
+    """Integration tests for FourierMMD drift metric registration."""
+
+    def test_fouriermmd_endpoints_in_openapi(self) -> None:
+        """FourierMMD endpoints are registered in OpenAPI."""
+        response = client.get("/openapi.json")
+        openapi = response.json()
+        for path in [
+            "/metrics/drift/fouriermmd",
+            "/metrics/drift/fouriermmd/definition",
+            "/metrics/drift/fouriermmd/request",
+            "/metrics/drift/fouriermmd/requests",
+        ]:
+            assert path in openapi["paths"], f"{path} not found in OpenAPI"
+
+
+class TestApproxKSTestMetricIntegration:
+    """Integration tests for ApproxKSTest drift metric registration."""
+
+    def test_approxkstest_endpoints_in_openapi(self) -> None:
+        """ApproxKSTest endpoints are registered in OpenAPI."""
+        response = client.get("/openapi.json")
+        openapi = response.json()
+        for path in [
+            "/metrics/drift/approxkstest",
+            "/metrics/drift/approxkstest/definition",
+            "/metrics/drift/approxkstest/request",
+            "/metrics/drift/approxkstest/requests",
+        ]:
+            assert path in openapi["paths"], f"{path} not found in OpenAPI"
+
+
+class TestJensenShannonMetricIntegration:
+    """Integration tests for JensenShannon drift metric registration."""
+
+    def test_jensenshannon_endpoints_in_openapi(self) -> None:
+        """JensenShannon endpoints are registered in OpenAPI."""
+        response = client.get("/openapi.json")
+        openapi = response.json()
+        for path in [
+            "/metrics/drift/jensenshannon",
+            "/metrics/drift/jensenshannon/definition",
+            "/metrics/drift/jensenshannon/request",
+            "/metrics/drift/jensenshannon/requests",
+        ]:
+            assert path in openapi["paths"], f"{path} not found in OpenAPI"


### PR DESCRIPTION
## Summary

The `fouriermmd`, `approxkstest`, and `jensenshannon` drift metric endpoints return 404 because their routers exist in the codebase but were never registered with the FastAPI app in `main.py`.

## Root cause

`src/main.py` only registered two drift routers (`drift_comparemeans_router` and `drift_kstest_router`), but three more drift endpoint files had routers that were never imported or included:

- `src/endpoints/metrics/drift/fourier_mmd.py` — routes at `/metrics/drift/fouriermmd`
- `src/endpoints/metrics/drift/approx_ks_test.py` — routes at `/metrics/drift/approxkstest`
- `src/endpoints/metrics/drift/jensen_shannon.py` — routes at `/metrics/drift/jensenshannon`

Evidence from agent logs:
```
"POST /metrics/drift/approxkstest/ 1.1" 404
"POST /metrics/drift/fouriermmd/ 1.1" 404
```

## The fix

Import and register the three missing routers in `main.py`, alongside the existing drift metric routers.

## Files changed

| File | Change |
|------|--------|
| `src/main.py` | Import and register `drift_fouriermmd_router`, `drift_approxkstest_router`, `drift_jensenshannon_router` |
| `tests/test_app_integration.py` | Add OpenAPI registration tests for all three new routers |

## Test plan

- [x] All 16 app integration tests pass (3 new router registration tests)
- [x] New tests verify all endpoints for each router appear in OpenAPI (`/metrics/drift/{metric}`, `.../definition`, `.../request`, `.../requests`)
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `pyrefly check` clean
- [x] Rebuild container image and verify endpoints no longer return 404

🤖 Generated with [Claude Code](https://claude.ai/claude-code)