### PR TITLE
fix(storage): accept DATABASE as alias for MARIA storage format

### DIFF
--- a/src/service/data/storage/__init__.py
+++ b/src/service/data/storage/__init__.py
@@ -56,7 +56,7 @@ def get_storage_interface() -> MariaDBStorage | PVCStorage:
             data_directory=os.environ.get("STORAGE_DATA_FOLDER", "/tmp"),  # noqa: S108 -- fallback default for STORAGE_DATA_FOLDER env var
             data_file=os.environ.get("STORAGE_DATA_FILENAME", "trustyai.hdf5"),
         )
-    if storage_format == "MARIA":
+    if storage_format in ("MARIA", "DATABASE"):
         try:
             # Import MariaDB storage only when needed (optional dependency)
             from src.service.data.storage.maria.maria import (  # noqa: PLC0415 -- lazy import: mariadb is optional

--- a/tests/service/data/test_storage_factory.py
+++ b/tests/service/data/test_storage_factory.py
@@ -1,0 +1,75 @@
+"""Tests for storage backend factory."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from src.service.data.storage import get_storage_interface
+from src.service.data.storage.pvc import PVCStorage
+
+
+class TestGetStorageInterface:
+    """Tests for get_storage_interface factory function."""
+
+    def test_pvc_is_default(self) -> None:
+        """PVC storage is returned when no format is specified."""
+        with patch.dict(os.environ, {"SERVICE_STORAGE_FORMAT": "PVC"}, clear=False):
+            storage = get_storage_interface()
+            assert isinstance(storage, PVCStorage)
+
+    def test_unsupported_format_raises(self) -> None:
+        """Unsupported format raises ValueError."""
+        with (
+            patch.dict(os.environ, {"SERVICE_STORAGE_FORMAT": "REDIS"}, clear=False),
+            pytest.raises(ValueError, match="not yet supported"),
+        ):
+            get_storage_interface()
+
+
+@pytest.mark.skipif(
+    not pytest.importorskip("mariadb", reason="mariadb not installed"),
+    reason="mariadb not installed",
+)
+class TestGetStorageInterfaceMariaDB:
+    """Tests for MariaDB storage format routing (requires mariadb package)."""
+
+    @patch(
+        "src.service.data.storage.maria.maria.MariaDBStorage.__init__",
+        return_value=None,
+    )
+    def test_maria_format_creates_mariadb(self, _mock_init: object) -> None:
+        """MARIA format returns MariaDBStorage."""
+        from src.service.data.storage.maria.maria import MariaDBStorage  # noqa: PLC0415
+
+        env = {
+            "SERVICE_STORAGE_FORMAT": "MARIA",
+            "DATABASE_USERNAME": "user",
+            "DATABASE_PASSWORD": "pass",  # pragma: allowlist secret
+            "DATABASE_HOST": "localhost",
+            "DATABASE_PORT": "3306",
+            "DATABASE_DATABASE": "testdb",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            storage = get_storage_interface()
+            assert isinstance(storage, MariaDBStorage)
+
+    @patch(
+        "src.service.data.storage.maria.maria.MariaDBStorage.__init__",
+        return_value=None,
+    )
+    def test_database_format_creates_mariadb(self, _mock_init: object) -> None:
+        """DATABASE format is accepted as alias for MARIA."""
+        from src.service.data.storage.maria.maria import MariaDBStorage  # noqa: PLC0415
+
+        env = {
+            "SERVICE_STORAGE_FORMAT": "DATABASE",
+            "DATABASE_USERNAME": "user",
+            "DATABASE_PASSWORD": "pass",  # pragma: allowlist secret
+            "DATABASE_HOST": "localhost",
+            "DATABASE_PORT": "3306",
+            "DATABASE_DATABASE": "testdb",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            storage = get_storage_interface()
+            assert isinstance(storage, MariaDBStorage)

--- a/tests/service/data/test_storage_factory.py
+++ b/tests/service/data/test_storage_factory.py
@@ -14,7 +14,9 @@ class TestGetStorageInterface:
 
     def test_pvc_is_default(self) -> None:
         """PVC storage is returned when no format is specified."""
-        with patch.dict(os.environ, {"SERVICE_STORAGE_FORMAT": "PVC"}, clear=False):
+        env = os.environ.copy()
+        env.pop("SERVICE_STORAGE_FORMAT", None)
+        with patch.dict(os.environ, env, clear=True):
             storage = get_storage_interface()
             assert isinstance(storage, PVCStorage)
 


### PR DESCRIPTION
## Summary

The operator sets `SERVICE_STORAGE_FORMAT=DATABASE` (matching the Java Quarkus convention), but the Python service only accepted `MARIA`, causing it to fall through to a `ValueError` and default to PVC storage. DB-storage integration tests then find no data and return 404.

## The fix

Accept `"DATABASE"` as an alias for `"MARIA"` in the storage format check:

```python
if storage_format in ("MARIA", "DATABASE"):
```

## Files changed

| File | Change |
|------|--------|
| `src/service/data/storage/__init__.py` | Accept `DATABASE` alongside `MARIA` |
| `tests/service/data/test_storage_factory.py` | 4 tests: PVC default, MARIA, DATABASE alias, unsupported format error |

## Test plan

- [x] `test_pvc_is_default` — PVC returned for `SERVICE_STORAGE_FORMAT=PVC`
- [x] `test_maria_format_creates_mariadb` — MARIA creates MariaDBStorage
- [x] `test_database_format_creates_mariadb` — DATABASE creates MariaDBStorage (the bug fix)
- [x] `test_unsupported_format_raises` — unknown format raises ValueError
- [x] MariaDB tests skip gracefully when `mariadb` package is not installed
- [x] `ruff check` clean
- [x] `pyrefly check` clean
- [ ] Deploy with `SERVICE_STORAGE_FORMAT=DATABASE` and verify MariaDB storage is used

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage configuration now supports an expanded range of database format options, improving flexibility in backend storage selection without requiring application changes.

* **Tests**
  * Comprehensive test suite added to validate storage backend factory routing behavior, configuration option handling, and error handling for unsupported storage formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->