### PR TITLE
fix(info): include inputSchema and outputSchema in /info response

### DIFF
--- a/src/endpoints/metadata.py
+++ b/src/endpoints/metadata.py
@@ -11,6 +11,7 @@ from src.service.constants import INPUT_SUFFIX, OUTPUT_SUFFIX
 from src.service.data.datasources.data_source import DataSource
 from src.service.data.shared_data_source import get_shared_data_source
 from src.service.data.storage import get_storage_interface
+from src.service.payloads.service.schema import Schema
 from src.service.prometheus.prometheus_scheduler import PrometheusScheduler
 from src.service.prometheus.shared_prometheus_scheduler import (
     get_shared_prometheus_scheduler,
@@ -20,6 +21,20 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 storage_interface = get_storage_interface()
+
+
+def _build_readable_schema(schema: Schema) -> dict:
+    """Convert a Schema to the Java-compatible ReadableSchema format."""
+    items = {}
+    for name, item in schema.items.items():
+        items[name] = {
+            "type": item.type.value if hasattr(item.type, "value") else str(item.type),
+            "index": item.column_index,
+        }
+    return {
+        "items": items,
+        "nameMapping": dict(schema.name_mapping),
+    }
 
 
 def get_data_source() -> DataSource:
@@ -120,6 +135,16 @@ async def get_service_info() -> dict[str, dict]:
                         "outputTensorName": model_metadata.output_tensor_name
                         if model_metadata
                         else "output",
+                        "inputSchema": _build_readable_schema(
+                            model_metadata.input_schema
+                        )
+                        if model_metadata
+                        else {"items": {}, "nameMapping": {}},
+                        "outputSchema": _build_readable_schema(
+                            model_metadata.output_schema
+                        )
+                        if model_metadata
+                        else {"items": {}, "nameMapping": {}},
                     },
                     "metrics": {"scheduledMetadata": scheduled_metadata},
                 }
@@ -142,6 +167,8 @@ async def get_service_info() -> dict[str, dict]:
                         "hasRecordedInferences": False,
                         "inputTensorName": "input",
                         "outputTensorName": "output",
+                        "inputSchema": {"items": {}, "nameMapping": {}},
+                        "outputSchema": {"items": {}, "nameMapping": {}},
                     },
                     "metrics": {"scheduledMetadata": {}},
                     "error": str(e),

--- a/src/endpoints/metadata.py
+++ b/src/endpoints/metadata.py
@@ -23,7 +23,11 @@ logger = logging.getLogger(__name__)
 storage_interface = get_storage_interface()
 
 
-def _build_readable_schema(schema: Schema) -> dict:
+def _build_readable_schema(
+    schema: Schema,
+    original_names: list[str],
+    aliased_names: list[str],
+) -> dict:
     """Convert a Schema to the Java-compatible ReadableSchema format."""
     items = {}
     for name, item in schema.items.items():
@@ -31,9 +35,14 @@ def _build_readable_schema(schema: Schema) -> dict:
             "type": item.type.value if hasattr(item.type, "value") else str(item.type),
             "index": item.column_index,
         }
+    name_mapping = {
+        orig: alias
+        for orig, alias in zip(original_names, aliased_names, strict=False)
+        if orig != alias
+    }
     return {
         "items": items,
-        "nameMapping": dict(schema.name_mapping),
+        "nameMapping": name_mapping,
     }
 
 
@@ -124,6 +133,22 @@ async def get_service_info() -> dict[str, dict]:
                         e,
                     )
 
+                # Fetch column names for name mapping
+                input_dataset = model_id + INPUT_SUFFIX
+                output_dataset = model_id + OUTPUT_SUFFIX
+                input_original = await storage_interface.get_original_column_names(
+                    input_dataset
+                )
+                input_aliased = await storage_interface.get_aliased_column_names(
+                    input_dataset
+                )
+                output_original = await storage_interface.get_original_column_names(
+                    output_dataset
+                )
+                output_aliased = await storage_interface.get_aliased_column_names(
+                    output_dataset
+                )
+
                 # Transform to match expected format
                 service_metadata[model_id] = {
                     "data": {
@@ -136,12 +161,16 @@ async def get_service_info() -> dict[str, dict]:
                         if model_metadata
                         else "output",
                         "inputSchema": _build_readable_schema(
-                            model_metadata.input_schema
+                            model_metadata.input_schema,
+                            input_original,
+                            input_aliased,
                         )
                         if model_metadata
                         else {"items": {}, "nameMapping": {}},
                         "outputSchema": _build_readable_schema(
-                            model_metadata.output_schema
+                            model_metadata.output_schema,
+                            output_original,
+                            output_aliased,
                         )
                         if model_metadata
                         else {"items": {}, "nameMapping": {}},

--- a/tests/endpoints/test_metadata_info.py
+++ b/tests/endpoints/test_metadata_info.py
@@ -1,0 +1,83 @@
+"""Tests for /info endpoint schema fields."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.endpoints.metadata import _build_readable_schema
+from src.main import app
+from src.service.payloads.service.schema import Schema
+from src.service.payloads.service.schema_item import SchemaItem
+from src.service.payloads.values.data_type import DataType
+
+client = TestClient(app)
+
+
+class TestBuildReadableSchema:
+    """Tests for _build_readable_schema helper."""
+
+    def test_converts_schema_with_items(self) -> None:
+        """Schema items are serialized with type and index."""
+        schema = Schema(
+            items={
+                "col1": SchemaItem(DataType.DOUBLE, "col1", 0),
+                "col2": SchemaItem(DataType.INT32, "col2", 1),
+            },
+        )
+        result = _build_readable_schema(schema)
+
+        assert result["items"]["col1"] == {"type": "DOUBLE", "index": 0}
+        assert result["items"]["col2"] == {"type": "INT32", "index": 1}
+        assert result["nameMapping"] == {}
+
+    def test_includes_name_mapping(self) -> None:
+        """Name mappings are included in the output."""
+        schema = Schema(
+            items={"col1": SchemaItem(DataType.DOUBLE, "col1", 0)},
+            name_mapping={"col1": "Friendly Name"},
+        )
+        result = _build_readable_schema(schema)
+
+        assert result["nameMapping"] == {"col1": "Friendly Name"}
+
+    def test_empty_schema(self) -> None:
+        """Empty schema returns empty items and nameMapping."""
+        schema = Schema()
+        result = _build_readable_schema(schema)
+
+        assert result == {"items": {}, "nameMapping": {}}
+
+
+class TestInfoEndpointSchema:
+    """Tests for /info endpoint inputSchema/outputSchema fields."""
+
+    @patch("src.endpoints.metadata.get_data_source")
+    @pytest.mark.asyncio
+    async def test_info_includes_schemas(self, mock_get_ds: MagicMock) -> None:
+        """The /info response includes inputSchema and outputSchema."""
+        mock_ds = MagicMock()
+        mock_ds.get_known_models = AsyncMock(return_value={"test-model"})
+
+        mock_metadata = MagicMock()
+        mock_metadata.input_tensor_name = "input"
+        mock_metadata.output_tensor_name = "output"
+        mock_metadata.input_schema = Schema(
+            items={"f1": SchemaItem(DataType.DOUBLE, "f1", 0)},
+        )
+        mock_metadata.output_schema = Schema(
+            items={"out": SchemaItem(DataType.DOUBLE, "out", 0)},
+        )
+        mock_ds.get_metadata = AsyncMock(return_value=mock_metadata)
+        mock_ds.get_num_observations = AsyncMock(return_value=100)
+        mock_ds.has_recorded_inferences = AsyncMock(return_value=True)
+        mock_get_ds.return_value = mock_ds
+
+        response = client.get("/info")
+
+        assert response.status_code == 200  # noqa: PLR2004
+        data = response.json()["test-model"]["data"]
+        assert "inputSchema" in data
+        assert "outputSchema" in data
+        assert data["inputSchema"]["items"]["f1"] == {"type": "DOUBLE", "index": 0}
+        assert data["outputSchema"]["items"]["out"] == {"type": "DOUBLE", "index": 0}

--- a/tests/endpoints/test_metadata_info.py
+++ b/tests/endpoints/test_metadata_info.py
@@ -25,26 +25,25 @@ class TestBuildReadableSchema:
                 "col2": SchemaItem(DataType.INT32, "col2", 1),
             },
         )
-        result = _build_readable_schema(schema)
+        result = _build_readable_schema(schema, ["col1", "col2"], ["col1", "col2"])
 
         assert result["items"]["col1"] == {"type": "DOUBLE", "index": 0}
         assert result["items"]["col2"] == {"type": "INT32", "index": 1}
         assert result["nameMapping"] == {}
 
     def test_includes_name_mapping(self) -> None:
-        """Name mappings are included in the output."""
+        """Name mappings derived from original vs aliased column names."""
         schema = Schema(
             items={"col1": SchemaItem(DataType.DOUBLE, "col1", 0)},
-            name_mapping={"col1": "Friendly Name"},
         )
-        result = _build_readable_schema(schema)
+        result = _build_readable_schema(schema, ["col1"], ["Friendly Name"])
 
         assert result["nameMapping"] == {"col1": "Friendly Name"}
 
     def test_empty_schema(self) -> None:
         """Empty schema returns empty items and nameMapping."""
         schema = Schema()
-        result = _build_readable_schema(schema)
+        result = _build_readable_schema(schema, [], [])
 
         assert result == {"items": {}, "nameMapping": {}}
 
@@ -52,9 +51,12 @@ class TestBuildReadableSchema:
 class TestInfoEndpointSchema:
     """Tests for /info endpoint inputSchema/outputSchema fields."""
 
+    @patch("src.endpoints.metadata.storage_interface")
     @patch("src.endpoints.metadata.get_data_source")
     @pytest.mark.asyncio
-    async def test_info_includes_schemas(self, mock_get_ds: MagicMock) -> None:
+    async def test_info_includes_schemas(
+        self, mock_get_ds: MagicMock, mock_storage: MagicMock
+    ) -> None:
         """The /info response includes inputSchema and outputSchema."""
         mock_ds = MagicMock()
         mock_ds.get_known_models = AsyncMock(return_value={"test-model"})
@@ -73,6 +75,13 @@ class TestInfoEndpointSchema:
         mock_ds.has_recorded_inferences = AsyncMock(return_value=True)
         mock_get_ds.return_value = mock_ds
 
+        mock_storage.get_original_column_names = AsyncMock(
+            side_effect=lambda ds: ["f1"] if "inputs" in ds else ["out"]
+        )
+        mock_storage.get_aliased_column_names = AsyncMock(
+            side_effect=lambda ds: ["Feature One"] if "inputs" in ds else ["out"]
+        )
+
         response = client.get("/info")
 
         assert response.status_code == 200  # noqa: PLR2004
@@ -80,4 +89,5 @@ class TestInfoEndpointSchema:
         assert "inputSchema" in data
         assert "outputSchema" in data
         assert data["inputSchema"]["items"]["f1"] == {"type": "DOUBLE", "index": 0}
-        assert data["outputSchema"]["items"]["out"] == {"type": "DOUBLE", "index": 0}
+        assert data["inputSchema"]["nameMapping"] == {"f1": "Feature One"}
+        assert data["outputSchema"]["nameMapping"] == {}


### PR DESCRIPTION
## Summary

The `/info` endpoint is missing `inputSchema` and `outputSchema` in the response, causing `KeyError: 'inputSchema'` in fairness tests that read name mappings. This blocks all 16+ fairness tests.

## Root cause

The `/info` response only included basic fields (`observations`, `hasRecordedInferences`, tensor names) but not the schema objects that the Java service returns via `ReadableStorageMetadata`. The `StorageMetadata` object has `input_schema` and `output_schema` attributes with column definitions and name mappings, but they were never serialized into the response.

## The fix

Add a `_build_readable_schema` helper that converts `Schema` objects to the Java-compatible `ReadableSchema` format:

```json
{
  "inputSchema": {
    "items": {"col1": {"type": "DOUBLE", "index": 0}},
    "nameMapping": {"col1": "Friendly Name"}
  },
  "outputSchema": {
    "items": {"output1": {"type": "DOUBLE", "index": 0}},
    "nameMapping": {}
  }
}
```

Schemas are included in both the success response and the error fallback (empty schemas) to prevent `KeyError` in either path.

## Files changed

| File | Change |
|------|--------|
| `src/endpoints/metadata.py` | Add `_build_readable_schema` helper, include schemas in both success and error `/info` responses |
| `tests/endpoints/test_metadata_info.py` | 4 tests: schema with items, name mapping, empty schema, full endpoint response |

## Test plan

- [x] `test_converts_schema_with_items` — schema items serialized with type and index
- [x] `test_includes_name_mapping` — name mappings included in output
- [x] `test_empty_schema` — empty schema returns empty items and nameMapping
- [x] `test_info_includes_schemas` — `/info` endpoint response contains inputSchema and outputSchema
- [x] All 117 tests pass
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `pyrefly check` clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The metadata endpoint now delivers enriched schema information for requests and responses, including detailed column type and index specifications with mappings between original and renamed column identifiers for enhanced readability and usability.

* **Tests**
  * Added comprehensive test coverage validating schema serialization logic and endpoint response structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->