### PR TITLE
fix(fairness): use type=metric in SPD and DIR responses to match Java API

### DIFF
--- a/src/endpoints/metrics/fairness/group/dir.py
+++ b/src/endpoints/metrics/fairness/group/dir.py
@@ -152,7 +152,7 @@ async def compute_dir(
         return {
             "name": "DIR",
             "value": result.get_value(),
-            "type": "FAIRNESS",
+            "type": "metric",
             "specificDefinition": f"Disparate Impact Ratio value of {result.get_value():.4f}",
             "thresholds": {
                 "lowerBound": DIR_FAIRNESS_TARGET - delta,

--- a/src/endpoints/metrics/fairness/group/spd.py
+++ b/src/endpoints/metrics/fairness/group/spd.py
@@ -158,7 +158,7 @@ async def compute_spd(
     return {
         "name": "SPD",
         "value": result.get_value(),
-        "type": "FAIRNESS",
+        "type": "metric",
         "specificDefinition": f"Statistical Parity Difference value of {result.get_value():.4f}",
         "thresholds": {
             "lowerBound": SPD_FAIRNESS_TARGET - delta,


### PR DESCRIPTION
## Summary

Both SPD and DIR fairness endpoints return `"type": "FAIRNESS"` in one-shot computation responses, but the Java service uses `"type": "metric"` (from `BaseMetricResponse`). Integration tests validate this field and fail with `MetricValidationError: Wrong type: FAIRNESS, expected: metric`.

## The fix

Change `"type": "FAIRNESS"` to `"type": "metric"` in both `dir.py` and `spd.py`.

## Note on SPD router registration

The doc also mentions SPD router not being registered. On `main`, SPD is correctly registered at `app.include_router(spd_router, ...)`. The missing registration is on the `integration/all-open-prs` branch where PR #127 (feature flags) rewrote the registration section and omitted SPD — that needs to be fixed on PR #127's branch, not here.

## Files changed

| File | Change |
|------|--------|
| `src/endpoints/metrics/fairness/group/dir.py` | `"type": "FAIRNESS"` → `"type": "metric"` |
| `src/endpoints/metrics/fairness/group/spd.py` | `"type": "FAIRNESS"` → `"type": "metric"` |

## Test plan

- [x] All 100 metrics tests pass
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `pyrefly check` clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the metric response format in fairness group-level endpoints to ensure consistent API responses across all metric calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->