### PR TITLE
chore(pre-commit): add Signed-off-by check to commit-msg hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,18 @@ repos:
         additional_dependencies: ["bandit[toml]"]
 
   # === COMMIT MESSAGE VALIDATION ===
+  - repo: local
+    hooks:
+      - id: check-signoff
+        name: Check Signed-off-by
+        stages: [commit-msg]
+        language: system
+        entry: >
+          bash -c 'grep -q "^Signed-off-by: .* <.*@.*>" "$1" ||
+          { echo "ERROR: Commit message must include a valid Signed-off-by trailer.";
+          echo "  Use: git commit -s";
+          echo "  Or add manually: Signed-off-by: Your Name <your@email.com>"; exit 1; }' --
+
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0
     hooks:


### PR DESCRIPTION
## Summary

Add a pre-commit `commit-msg` hook that rejects commits without a valid `Signed-off-by` trailer. Matches the pattern used in [opendatahub-tests](https://github.com/opendatahub-io/opendatahub-tests).

## How it works

Simple bash grep in a local hook — no external dependencies:

```yaml
- repo: local
  hooks:
    - id: check-signoff
      name: Check Signed-off-by
      stages: [commit-msg]
      language: system
      entry: >
        bash -c 'grep -q "^Signed-off-by: .* <.*@.*>" "$1" || ...' --
```

- Without `-s`: **rejected** with clear instructions
- With `-s` or manual `Signed-off-by:` trailer: **passes**

## Files changed

| File | Change |
|------|--------|
| `.pre-commit-config.yaml` | Add `check-signoff` hook before conventional commit check |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)