### PR TITLE
fix(security): remove user-controllable lm_eval_path to prevent command injection

### DIFF
--- a/src/endpoints/evaluation/lm_evaluation_harness.py
+++ b/src/endpoints/evaluation/lm_evaluation_harness.py
@@ -68,9 +68,12 @@ class AllLMEvalJobs(BaseModel):
 
 
 # === Dynamic API Object from LM-Eval CLI ==========================================================
+# Executable path is server-side only — never user-controllable (CWE-78 mitigation).
+# Override via LM_EVAL_PATH env var at deployment time if needed.
+LM_EVAL_EXECUTABLE = os.environ.get("LM_EVAL_PATH", f"{sys.executable} -m lm_eval")
+
 NON_CLI_ARGUMENTS = {
     "env_vars": (dict[str, str], {}),
-    "lm_eval_path": (str, f"{sys.executable} -m lm_eval"),
 }
 
 
@@ -243,7 +246,7 @@ def convert_to_cli(request: BaseModel) -> str:
         get_lm_eval_arguments()
     )  # grab the cli argument spec to translate json to cli
 
-    cli_cmd = request.lm_eval_path  # type: ignore[attr-defined]
+    cli_cmd = LM_EVAL_EXECUTABLE
     for field in request.model_fields_set:
         if field in NON_CLI_ARGUMENTS:
             continue
@@ -352,8 +355,8 @@ def _launch_job(job: LMEvalJob) -> None:
     # Merge environment variables (user overrides take precedence)
     merged_env = {**os.environ, **job.request.env_vars}
 
-    # Arguments are safely parsed using shlex.split() which prevents command injection
-    p = subprocess.Popen(  # noqa: S603  # args safely parsed via shlex.split
+    # Executable is a server-side constant (LM_EVAL_EXECUTABLE); CLI args are shlex.quote()'d
+    p = subprocess.Popen(  # noqa: S603  # executable hardcoded, args quoted
         shlex.split(job.argument),
         env=merged_env,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
## Summary

- Remove `lm_eval_path` from the user-controllable Pydantic request model to eliminate CWE-78 (OS Command Injection) in the LM Evaluation Harness endpoint
- Introduce `LM_EVAL_EXECUTABLE` as a server-side constant, configurable via the `LM_EVAL_PATH` environment variable at deployment time
- Update `# nosec`/`# noqa` justification comments to reflect the hardcoded executable

Fixes #189
Resolves: RHOAIENG-56134

## Problem

The `lm_eval_path` field accepted arbitrary executable paths from API consumers via `POST /eval/lm-evaluation-harness/job`. This value was deliberately excluded from `shlex.quote()` protection (via the `NON_CLI_ARGUMENTS` skip list) and flowed directly into `subprocess.Popen`, enabling remote code execution. An attacker could set `lm_eval_path` to `/bin/bash -c '<malicious>'` to execute arbitrary commands as UID 1001.

Originally identified by CodeRabbit in [PR #104](https://github.com/trustyai-explainability/trustyai-service/pull/104#discussion_r2030855131) (April 2026). The suggested fix in that review matches this implementation.

## Changes

| Before | After |
|--------|-------|
| `lm_eval_path` is a user-controllable string field in `NON_CLI_ARGUMENTS` | Removed from request model entirely |
| `cli_cmd = request.lm_eval_path` reads from HTTP body | `cli_cmd = LM_EVAL_EXECUTABLE` reads from server-side constant |
| `# noqa: S603` justified as "args safely parsed" | Justified as "executable hardcoded, args quoted" |

## Compatibility

- **Default behavior unchanged** — `LM_EVAL_EXECUTABLE` defaults to `f"{sys.executable} -m lm_eval"`, the same value as the previous field default
- **No API consumer uses this field** — searched across trustyai-service-operator, opendatahub-io, and red-hat-data-services; zero references found
- **Existing clients sending `lm_eval_path`** — Pydantic v2 silently ignores unknown fields (default `extra` behavior), so no errors
- **Deployment customization preserved** — set `LM_EVAL_PATH` env var instead of per-request override

## Test plan

- [x] `ruff check` — all checks passed
- [x] `ruff format` — already formatted
- [x] `pyrefly check` — 0 errors
- [x] `bandit` — 0 issues
- [ ] Verify lm-eval job submission still works with default path
- [ ] Verify `LM_EVAL_PATH` env var override works at startup
- [ ] Verify sending `lm_eval_path` in request body is silently ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the ability to specify evaluation executable paths in requests. This configuration is now managed exclusively server-side.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->