### PR TITLE
fix(security): sanitize env_vars in LM-Eval endpoint (CWE-426/427)

### DIFF
--- a/src/endpoints/evaluation/_env_security.py
+++ b/src/endpoints/evaluation/_env_security.py
@@ -1,0 +1,152 @@
+"""Environment variable validation for LM-Eval subprocess isolation.
+
+Provides a two-layer defense against CWE-426/427 (Untrusted Search Path):
+  1. API-boundary validation — reject dangerous or unrecognised env var names
+  2. Minimal environment construction — subprocess inherits only ML-related vars
+
+This module is deliberately free of lm-eval and FastAPI dependencies so that
+its security logic can be tested independently.
+"""
+
+import os
+
+from pydantic import BaseModel
+
+# Dangerous vars that enable code injection or traffic interception.
+BLOCKED_ENV_VARS: frozenset[str] = frozenset(
+    {
+        # Dynamic linker injection
+        "LD_PRELOAD",
+        "LD_LIBRARY_PATH",
+        "LD_AUDIT",
+        "LD_DEBUG",
+        "LD_PROFILE",
+        # Python import/startup hijack
+        "PYTHONPATH",
+        "PYTHONSTARTUP",
+        "PYTHONHOME",
+        # Executable search path
+        "PATH",
+        # Shell injection vectors
+        "BASH_ENV",
+        "ENV",
+        "CDPATH",
+        "HOSTALIASES",
+        # Proxy hijack (data exfiltration via MITM)
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+        "no_proxy",
+    }
+)
+
+# Prefixes covering the ML ecosystem env vars (lm-eval, torch, transformers,
+# accelerate, huggingface_hub, experiment trackers, GPU runtimes).
+ALLOWED_ENV_PREFIXES: tuple[str, ...] = (
+    "HF_",
+    "HUGGING",
+    "TRANSFORMERS_",
+    "ACCELERATE_",
+    "FSDP_",
+    "CUDA_",
+    "NCCL_",
+    "ROCR_",
+    "HIP_",
+    "WANDB_",
+    "MLFLOW_",
+    "CLEARML_",
+    "TOKENIZERS_",
+    "FLASH_ATTENTION_",
+    "LM_HARNESS_",
+    "TORCH_",
+    "INDUCTOR_",
+)
+
+# Individual vars that don't match a prefix but are legitimate for lm-eval jobs.
+ALLOWED_ENV_EXACT: frozenset[str] = frozenset(
+    {
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "TEXTSYNTH_API_SECRET_KEY",
+        "PERSPECTIVE_API_KEY",
+        "PERSPECTIVE_API_QPS",
+        "MASTER_ADDR",
+        "MASTER_PORT",
+        "LOCAL_RANK",
+        "WORLD_SIZE",
+        "NODE_RANK",
+        "NPROC",
+        "CUDA_VISIBLE_DEVICES",
+        "HIP_VISIBLE_DEVICES",
+        "TOKENIZERS_PARALLELISM",
+    }
+)
+
+
+def is_env_var_allowed(name: str) -> bool:
+    """Check whether an environment variable name is permitted."""
+    if name in BLOCKED_ENV_VARS:
+        return False
+    if name in ALLOWED_ENV_EXACT:
+        return True
+    return any(name.startswith(p) for p in ALLOWED_ENV_PREFIXES)
+
+
+def validate_env_var_names(env_vars: dict[str, str]) -> None:
+    """Validate that all env var names are allowed.
+
+    Raises ValueError listing any rejected names.
+    """
+    if not env_vars:
+        return
+    blocked = {k for k in env_vars if k in BLOCKED_ENV_VARS}
+    if blocked:
+        msg = f"Blocked environment variables (security risk): {', '.join(sorted(blocked))}"
+        raise ValueError(msg)
+    rejected = {k for k in env_vars if not is_env_var_allowed(k)}
+    if rejected:
+        msg = (
+            f"Unrecognised environment variables: {', '.join(sorted(rejected))}. "
+            f"Allowed prefixes: {', '.join(ALLOWED_ENV_PREFIXES)}"
+        )
+        raise ValueError(msg)
+
+
+def validate_env_vars_model(self: BaseModel) -> BaseModel:
+    """Pydantic model_validator for env_vars on the dynamic LMEvalRequest model."""
+    env_vars = getattr(self, "env_vars", None)
+    if env_vars:
+        validate_env_var_names(env_vars)
+    return self
+
+
+def build_subprocess_env(user_env_vars: dict[str, str]) -> dict[str, str]:
+    """Build a minimal subprocess environment.
+
+    Starts with essential base vars, selectively inherits ML-related vars
+    from the server environment, then overlays validated user-supplied vars.
+    Server secrets (DATABASE_PASSWORD, TLS_KEY_FILE, etc.) are never passed.
+
+    ``user_env_vars`` must contain only allowed names (see
+    :func:`validate_env_var_names`).  A defensive re-validation is performed
+    here so that callers who bypass the Pydantic model layer are still safe.
+    """
+    validate_env_var_names(user_env_vars)
+    env: dict[str, str] = {
+        "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/tmp"),  # noqa: S108
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+    }
+    env.update(
+        {
+            key: val
+            for key, val in os.environ.items()
+            if any(key.startswith(p) for p in ALLOWED_ENV_PREFIXES)
+        }
+    )
+    env.update(user_env_vars)
+    return env

--- a/src/endpoints/evaluation/lm_evaluation_harness.py
+++ b/src/endpoints/evaluation/lm_evaluation_harness.py
@@ -25,7 +25,12 @@ from typing import Any, TextIO
 
 from fastapi import APIRouter, HTTPException
 from fastapi.applications import FastAPI
-from pydantic import BaseModel, create_model
+from pydantic import BaseModel, create_model, model_validator
+
+from src.endpoints.evaluation._env_security import (
+    build_subprocess_env,
+    validate_env_vars_model,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +110,13 @@ def get_model() -> type[BaseModel]:
     args = get_lm_eval_arguments()
     model_args = {k: (v["type"], v["default"]) for k, v in args.items()}
     model_args.update(NON_CLI_ARGUMENTS)
-    return create_model("LMEvalRequest", **model_args)
+    return create_model(
+        "LMEvalRequest",
+        __validators__={
+            "_check_env_vars": model_validator(mode="after")(validate_env_vars_model),
+        },
+        **model_args,
+    )
 
 
 # Dynamically create the lm-eval-harness job request from the library's argparse
@@ -349,13 +360,12 @@ def _launch_job(job: LMEvalJob) -> None:
     logger.debug("Launching lm-eval job %s", job.job_id)
     logger.debug("Launching with custom env vars: %s keys", len(job.request.env_vars))
 
-    # Merge environment variables (user overrides take precedence)
-    merged_env = {**os.environ, **job.request.env_vars}
+    env = build_subprocess_env(job.request.env_vars)
 
     # Arguments are safely parsed using shlex.split() which prevents command injection
     p = subprocess.Popen(  # noqa: S603  # args safely parsed via shlex.split
         shlex.split(job.argument),
-        env=merged_env,
+        env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,

--- a/tests/endpoints/test_lm_eval_env_vars.py
+++ b/tests/endpoints/test_lm_eval_env_vars.py
@@ -1,0 +1,241 @@
+"""Tests for LM-Eval environment variable validation and subprocess env construction.
+
+The security functions are in ``_env_security.py`` which has no lm-eval
+dependency, so these tests run regardless of whether lm-eval is installed.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from src.endpoints.evaluation._env_security import (
+    ALLOWED_ENV_EXACT,
+    ALLOWED_ENV_PREFIXES,
+    BLOCKED_ENV_VARS,
+    build_subprocess_env,
+    is_env_var_allowed,
+    validate_env_var_names,
+)
+
+
+class TestIsEnvVarAllowed:
+    """Test the is_env_var_allowed predicate."""
+
+    @pytest.mark.parametrize("var", sorted(BLOCKED_ENV_VARS))
+    def test_blocked_vars_rejected(self, var: str) -> None:
+        """Ensure every blocked variable is rejected."""
+        assert is_env_var_allowed(var) is False
+
+    @pytest.mark.parametrize(
+        "var",
+        [
+            "HF_TOKEN",
+            "HF_HOME",
+            "HUGGINGFACE_HUB_CACHE",
+            "TRANSFORMERS_CACHE",
+            "ACCELERATE_USE_FSDP",
+            "CUDA_VISIBLE_DEVICES",
+            "NCCL_DEBUG",
+            "WANDB_PROJECT",
+            "MLFLOW_EXPERIMENT_NAME",
+            "TOKENIZERS_PARALLELISM",
+            "LM_HARNESS_CACHE_PATH",
+            "TORCH_DTYPE",
+            "FLASH_ATTENTION_DETERMINISTIC",
+        ],
+    )
+    def test_prefix_vars_allowed(self, var: str) -> None:
+        """Ensure ML ecosystem prefix vars are accepted."""
+        assert is_env_var_allowed(var) is True
+
+    @pytest.mark.parametrize("var", sorted(ALLOWED_ENV_EXACT))
+    def test_exact_vars_allowed(self, var: str) -> None:
+        """Ensure every exact-match var is accepted."""
+        assert is_env_var_allowed(var) is True
+
+    @pytest.mark.parametrize(
+        "var",
+        [
+            "DATABASE_PASSWORD",
+            "DATABASE_HOST",
+            "TLS_KEY_FILE",
+            "MY_CUSTOM_VAR",
+            "SECRET_TOKEN",
+        ],
+    )
+    def test_unknown_vars_rejected(self, var: str) -> None:
+        """Ensure server-internal and arbitrary vars are rejected."""
+        assert is_env_var_allowed(var) is False
+
+
+class TestValidateEnvVarNames:
+    """Test the validate_env_var_names validation function."""
+
+    def test_empty_dict_passes(self) -> None:
+        """Empty env_vars should not raise."""
+        validate_env_var_names({})
+
+    def test_allowed_vars_pass(self) -> None:
+        """Mix of prefix and exact-match vars should pass."""
+        validate_env_var_names(
+            {
+                "HF_TOKEN": "hf_abc123",
+                "CUDA_VISIBLE_DEVICES": "0,1",
+                "OPENAI_API_KEY": "sk-test",  # pragma: allowlist secret
+            }
+        )
+
+    def test_blocked_var_raises(self) -> None:
+        """A blocked variable should raise with 'Blocked' in the message."""
+        with pytest.raises(ValueError, match="Blocked environment variables"):
+            validate_env_var_names({"LD_PRELOAD": "evil.so"})
+
+    def test_blocked_var_message_lists_names(self) -> None:
+        """Error message should list all blocked variable names."""
+        with pytest.raises(ValueError, match="LD_PRELOAD") as exc_info:
+            validate_env_var_names(
+                {
+                    "LD_PRELOAD": "evil.so",
+                    "PYTHONPATH": "evil",
+                }
+            )
+        assert "PYTHONPATH" in str(exc_info.value)
+
+    def test_blocked_takes_precedence_over_unknown(self) -> None:
+        """When both blocked and unknown vars present, report blocked first."""
+        with pytest.raises(ValueError, match="Blocked"):
+            validate_env_var_names(
+                {
+                    "LD_PRELOAD": "evil",
+                    "MY_UNKNOWN": "value",
+                }
+            )
+
+    def test_unknown_var_raises(self) -> None:
+        """An unrecognised variable should raise with 'Unrecognised' in the message."""
+        with pytest.raises(ValueError, match="Unrecognised environment variables"):
+            validate_env_var_names({"MY_CUSTOM_VAR": "value"})
+
+    def test_unknown_var_message_lists_prefixes(self) -> None:
+        """Error for unknown vars should list allowed prefixes."""
+        with pytest.raises(ValueError, match="Allowed prefixes") as exc_info:
+            validate_env_var_names({"UNKNOWN": "value"})
+        assert "HF_" in str(exc_info.value)
+
+    def test_mixed_allowed_and_blocked_raises(self) -> None:
+        """A request with both allowed and blocked vars should still reject."""
+        with pytest.raises(ValueError, match="Blocked"):
+            validate_env_var_names(
+                {
+                    "HF_TOKEN": "valid",
+                    "PATH": "/evil/bin",
+                }
+            )
+
+    def test_proxy_vars_blocked(self) -> None:
+        """All proxy-related vars (upper and lowercase) should be blocked."""
+        for var in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
+            with pytest.raises(ValueError, match="Blocked"):
+                validate_env_var_names({var: "http://evil.proxy:8080"})
+
+    def test_all_prefixes_have_coverage(self) -> None:
+        """Every allowed prefix should actually match when used."""
+        for prefix in ALLOWED_ENV_PREFIXES:
+            var = f"{prefix}TEST_COVERAGE"
+            assert is_env_var_allowed(var), f"Prefix {prefix} not matching"
+
+
+class TestBuildSubprocessEnv:
+    """Test the build_subprocess_env function."""
+
+    @patch.dict(
+        "os.environ",
+        {
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/home/test",
+            "LANG": "en_US.UTF-8",
+            "HF_TOKEN": "hf_server_token",
+            "CUDA_VISIBLE_DEVICES": "0,1,2,3",
+            "DATABASE_PASSWORD": "supersecret",  # pragma: allowlist secret
+            "DATABASE_HOST": "db.internal",
+            "TLS_KEY_FILE": "/etc/tls/key.pem",
+            "SERVICE_STORAGE_FORMAT": "PVC",
+        },
+        clear=True,
+    )
+    def test_base_vars_present(self) -> None:
+        """Subprocess env should always include PATH, HOME, LANG."""
+        env = build_subprocess_env({})
+        assert "PATH" in env
+        assert "HOME" in env
+        assert "LANG" in env
+
+    @patch.dict(
+        "os.environ",
+        {
+            "PATH": "/usr/bin",
+            "HOME": "/home/test",
+            "HF_TOKEN": "hf_server",
+            "CUDA_VISIBLE_DEVICES": "0",
+            "NCCL_DEBUG": "INFO",
+        },
+        clear=True,
+    )
+    def test_ml_vars_inherited(self) -> None:
+        """ML ecosystem vars from the server env should pass through."""
+        env = build_subprocess_env({})
+        assert env["HF_TOKEN"] == "hf_server"  # noqa: S105
+        assert env["CUDA_VISIBLE_DEVICES"] == "0"
+        assert env["NCCL_DEBUG"] == "INFO"
+
+    @patch.dict(
+        "os.environ",
+        {
+            "PATH": "/usr/bin",
+            "HOME": "/home/test",
+            "DATABASE_PASSWORD": "supersecret",  # pragma: allowlist secret
+            "DATABASE_HOST": "db.internal",
+            "TLS_KEY_FILE": "/etc/tls/key.pem",
+            "SERVICE_STORAGE_FORMAT": "PVC",
+        },
+        clear=True,
+    )
+    def test_server_secrets_excluded(self) -> None:
+        """Server-internal secrets must never reach the subprocess."""
+        env = build_subprocess_env({})
+        assert "DATABASE_PASSWORD" not in env
+        assert "DATABASE_HOST" not in env
+        assert "TLS_KEY_FILE" not in env
+        assert "SERVICE_STORAGE_FORMAT" not in env
+
+    @patch.dict(
+        "os.environ",
+        {
+            "PATH": "/usr/bin",
+            "HOME": "/home/test",
+            "HF_TOKEN": "server_token",
+        },
+        clear=True,
+    )
+    def test_user_vars_override_server(self) -> None:
+        """User-supplied vars should override same-named server vars."""
+        env = build_subprocess_env({"HF_TOKEN": "user_token"})
+        assert env["HF_TOKEN"] == "user_token"  # noqa: S105
+
+    @patch.dict(
+        "os.environ",
+        {"PATH": "/usr/bin", "HOME": "/home/test"},
+        clear=True,
+    )
+    def test_user_vars_added(self) -> None:
+        """User-supplied vars should appear in the subprocess env."""
+        env = build_subprocess_env({"WANDB_PROJECT": "my-eval"})
+        assert env["WANDB_PROJECT"] == "my-eval"
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_defaults_when_env_empty(self) -> None:
+        """When host env is empty, sensible defaults should be used."""
+        env = build_subprocess_env({})
+        assert env["PATH"] == "/usr/local/bin:/usr/bin:/bin"
+        assert env["HOME"] == "/tmp"  # noqa: S108
+        assert env["LANG"] == "C.UTF-8"


### PR DESCRIPTION
## Summary

Fixes #191

- Add API-boundary validation that rejects blocked env var names (`LD_PRELOAD`, `PATH`, `PYTHONPATH`, proxy vars) and unknown names not matching ML ecosystem prefixes (`HF_*`, `CUDA_*`, `NCCL_*`, etc.)
- Replace `{**os.environ, **job.request.env_vars}` with minimal subprocess environment construction that only passes through essential base vars + ML-related vars, preventing server secret leakage (`DATABASE_PASSWORD`, `TLS_KEY_FILE`)
- Extract security functions into `_env_security.py` module with no lm-eval dependency for independent testability

## Files Changed

| File | Change |
|------|--------|
| `src/endpoints/evaluation/_env_security.py` | New — validation constants, `is_env_var_allowed()`, `validate_env_var_names()`, `validate_env_vars_model()`, `build_subprocess_env()` |
| `src/endpoints/evaluation/lm_evaluation_harness.py` | Wire validator into `create_model()` via `__validators__`, replace unsafe env merge in `_launch_job()` |
| `tests/endpoints/test_lm_eval_env_vars.py` | New — 69 tests covering blocklist, prefix allowlist, exact allowlist, subprocess env construction |

## Test plan

- [x] `uv run ruff check` — passes
- [x] `uv run ruff format --check` — passes
- [x] `uv run pyrefly check` — passes
- [x] `uv run bandit -c pyproject.toml -r src/endpoints/evaluation/` — passes
- [x] `uv run pytest tests/endpoints/test_lm_eval_env_vars.py -v` — 69/69 pass
- [x] `uv run pytest tests/ -v -k "not maria"` — 511/511 pass, no regressions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment variables submitted with evaluation jobs are now validated against security policies to prevent high-risk variables from reaching subprocesses, ensuring proper isolation.

* **Tests**
  * Added comprehensive test coverage for environment variable security validation and subprocess environment construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->