### PR TITLE
fix(tests): add ssl_ca=None to MariaDB storage init assertions

### DIFF
--- a/tests/service/data/test_storage_init.py
+++ b/tests/service/data/test_storage_init.py
@@ -67,6 +67,7 @@ class TestStorageInterfaceEnvVars:
                 host="localhost",
                 port=DEFAULT_MARIADB_PORT,
                 database="test_db",
+                ssl_ca=None,
                 attempt_migration=False,
             )
 
@@ -97,6 +98,7 @@ class TestStorageInterfaceEnvVars:
                 host="mariadb-service",
                 port=ALTERNATE_MARIADB_PORT,
                 database="operator_db",
+                ssl_ca=None,
                 attempt_migration=False,
             )
 
@@ -127,6 +129,7 @@ class TestStorageInterfaceEnvVars:
                 host="direct_host",
                 port=DEFAULT_MARIADB_PORT,
                 database="direct_db",
+                ssl_ca=None,
                 attempt_migration=False,
             )
 
@@ -155,6 +158,7 @@ class TestStorageInterfaceEnvVars:
                 host="mixed_host",
                 port=DEFAULT_MARIADB_PORT,
                 database="mixed_db",
+                ssl_ca=None,
                 attempt_migration=False,
             )
 
@@ -183,6 +187,7 @@ class TestStorageInterfaceEnvVars:
                 host="mariadb-service",
                 port=DEFAULT_MARIADB_PORT,
                 database="operator_db",
+                ssl_ca=None,
                 attempt_migration=False,
             )
 
@@ -213,6 +218,7 @@ class TestStorageInterfaceEnvVars:
                 host="mariadb-service",
                 port=DEFAULT_MARIADB_PORT,
                 database="operator_db",
+                ssl_ca=None,
                 attempt_migration=False,
             )
 
@@ -245,6 +251,7 @@ class TestStorageInterfaceEnvVars:
                 host="localhost",
                 port=DEFAULT_MARIADB_PORT,
                 database="test_db",
+                ssl_ca=None,
                 attempt_migration=False,
             )
 


### PR DESCRIPTION
## Summary
- Fix 7 failing tests in `test_storage_init.py` on `main`
- PR #181 added `ssl_ca` parameter to `MariaDBStorage()` but did not update test assertions

## Problem
Every open PR is failing CI because `test_storage_init.py` asserts `MariaDBStorage()` calls without `ssl_ca`, but the actual calls now include `ssl_ca=None`.

## Fix
Add `ssl_ca=None` to all 7 `assert_called_once_with()` expectations.

## Test plan
- [x] `uv run pytest tests/service/data/test_storage_init.py -v` — 15/15 pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated MariaDB storage initialization test assertions to reflect current expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->