### PR TITLE
fix(container): bump uv to 0.11.22, remove uv/uvx from runtime

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -37,9 +37,10 @@ USER 1001
 
 COPY pyproject.toml README.md ./
 
-RUN pip install --no-cache-dir --upgrade pip==26.1.1 uv==0.11.1 && \
+RUN pip install --no-cache-dir --upgrade pip==26.1.1 uv==0.11.22 && \
     uv pip install --no-cache ".[$EXTRAS]" && \
     pip uninstall -y uv && \
+    rm -f /opt/app-root/bin/uv /opt/app-root/bin/uvx && \
     rm -rf /root/.cache /tmp/*
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Bumps `uv` from 0.11.1 to 0.11.22 in the Containerfile builder stage (fix version: 0.11.15)
- Explicitly removes `uv`/`uvx` binaries from the builder's `bin/` directory before copying to the runtime stage — they are not needed at runtime and their presence unnecessarily expands the attack surface

## Security
Resolves [GHSA-4gg8-gxpx-9rph](https://github.com/advisories/GHSA-4gg8-gxpx-9rph) — arbitrary file write through entry point names in uv < 0.11.15.

## Test plan
- [x] CI container build passes
- [x] CI: lint, type-check, bandit, tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)