### PR TITLE
feat: enable RHEL AI dynamic versioning (ADR0170)

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -32,23 +32,34 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           if [[ "${GIT_REF}" == refs/tags/v* ]]; then
-            # Push both version tag and latest for releases
-            echo "tags=${REF_NAME} latest" >> "$GITHUB_OUTPUT"
-            echo "primary_tag=${REF_NAME}" >> "$GITHUB_OUTPUT"
+            # Full version from tag (strip v prefix)
+            VERSION="${REF_NAME#v}"
+            # Sanitize for OCI image tag: replace + with - (OCI tags: [a-zA-Z0-9._-])
+            SANITIZED_TAG="${REF_NAME//+/-}"
+            echo "tags=${SANITIZED_TAG} latest" >> "$GITHUB_OUTPUT"
+            echo "primary_tag=${SANITIZED_TAG}" >> "$GITHUB_OUTPUT"
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           else
             # Push only latest for main branch
             echo "tags=latest" >> "$GITHUB_OUTPUT"
             echo "primary_tag=latest" >> "$GITHUB_OUTPUT"
+            echo "version=0.0.0.dev0" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build image
         env:
           QUAY_REPO: ${{ vars.QUAY_RELEASE_REPO }}
           TAGS: ${{ steps.tags.outputs.tags }}
+          VERSION: ${{ steps.tags.outputs.version }}
+          VCS_REF: ${{ github.sha }}
         run: |
           # Build image with first tag
           FIRST_TAG=$(echo "${TAGS}" | awk '{print $1}')
-          docker build -f Containerfile -t "${QUAY_REPO}:${FIRST_TAG}" .
+          docker build -f Containerfile \
+            --build-arg VERSION="${VERSION}" \
+            --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            --build-arg VCS_REF="${VCS_REF}" \
+            -t "${QUAY_REPO}:${FIRST_TAG}" .
 
           # Tag with additional tags if present
           for tag in ${TAGS}; do

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -35,7 +35,7 @@ jobs:
           grep -A 1 'org.opencontainers.image.base.name=' Containerfile | grep -q 'quay.expires-after=7d' || { echo "::error::Failed to inject quay.expires-after label after base.name line"; exit 1; }
 
       - name: Build image
-        run: docker build -f Containerfile -t trustyai-ci:${{ github.event.pull_request.head.sha }} .
+        run: docker build -f Containerfile --build-arg VERSION="0.0.0.dev0" -t trustyai-ci:${{ github.event.pull_request.head.sha }} .
 
       - name: Save image
         run: docker save trustyai-ci:${{ github.event.pull_request.head.sha }} | gzip > /tmp/image.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# hatch-vcs auto-generated version file
+src/_version.py
+
 # C extensions
 *.so
 

--- a/Containerfile
+++ b/Containerfile
@@ -2,7 +2,7 @@
 # FIPS crypto policy support included.
 
 ARG EXTRAS=""
-ARG VERSION="1.0.0rc0"
+ARG VERSION="0.0.0.dev0"
 ARG BUILD_DATE
 ARG VCS_REF
 ARG ENABLE_FIPS_POLICY="true"
@@ -37,7 +37,10 @@ USER 1001
 
 COPY pyproject.toml README.md ./
 
-RUN pip install --no-cache-dir --upgrade pip==26.1.1 uv==0.11.22 && \
+ENV SETUPTOOLS_SCM_PRETEND_VERSION="0.0.0.dev0"
+
+RUN mkdir -p src && \
+    pip install --no-cache-dir --upgrade pip==26.1.1 uv==0.11.22 && \
     uv pip install --no-cache ".[$EXTRAS]" && \
     pip uninstall -y uv && \
     rm -f /opt/app-root/bin/uv /opt/app-root/bin/uvx && \
@@ -98,6 +101,9 @@ COPY --from=builder /opt/app-root/bin /opt/app-root/bin
 
 COPY src src
 COPY pyproject.toml README.md ./
+
+RUN printf '__version__ = version = "%s"\n' "${VERSION}" > src/_version.py && \
+    chown 1001:0 src/_version.py
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trustyai-service"
-version = "1.0.0rc0"
+dynamic = ["version"]
 description = "TrustyAI Service"
 authors = [{ name = "Rui Vieira" }, { name = "TrustyAI team" }]
 requires-python = ">=3.12, <3.15"
@@ -62,19 +62,30 @@ eval = [
 # Note: grpcio/grpcio-tools removed - incompatible with protobuf v7, unused (protoc used instead)
 mariadb = ["mariadb>=1.1,<1.2", "javaobj-py3>=0.5,<0.6"]
 
+[tool.hatch.version]
+source = "vcs"
+fallback-version = "0.0.0.dev0"
+
+[tool.hatch.version.raw-options]
+version_scheme = "no-guess-dev"
+local_scheme = "dirty-tag"
+
 [tool.hatch.build.targets.sdist]
 include = ["src"]
 
 [tool.hatch.build.targets.wheel]
 include = ["src"]
 
+[tool.hatch.build.hooks.vcs]
+version-file = "src/_version.py"
+
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.ruff]
 # Exclude generated protobuf files from all ruff operations
-exclude = ["src/proto/grpc_predict_v2_pb2.py"]
+exclude = ["src/proto/grpc_predict_v2_pb2.py", "src/_version.py"]
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -131,7 +142,7 @@ skips = [
 ]
 
 [tool.pyrefly]
-project-excludes = ["**/proto/**", "src/proto/**", "src/proto/grpc_predict_v2_pb2.py"]
+project-excludes = ["**/proto/**", "src/proto/**", "src/proto/grpc_predict_v2_pb2.py", "src/_version.py"]
 disable-project-excludes-heuristics = true
 # Forward-looking: pyrefly uses this for type checking, not runtime
 python-version = "3.14.0"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,6 @@
 """TrustyAI service - AI model monitoring and explainability."""
+
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = "0.0.0.dev0"

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import FastAPI, Request, Response
 
+from src import __version__
+
 if TYPE_CHECKING:
     from fastapi import APIRouter
 from fastapi.middleware.cors import CORSMiddleware
@@ -109,7 +111,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
 
 app = FastAPI(
     title="TrustyAI Service API",
-    version="1.0.0rc0",
+    version=__version__,
     description="TrustyAI Service API",
     lifespan=lifespan,
 )

--- a/uv.lock
+++ b/uv.lock
@@ -3290,7 +3290,6 @@ wheels = [
 
 [[package]]
 name = "trustyai-service"
-version = "1.0.0rc0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -3354,7 +3353,7 @@ types = [
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=48.0.1,<50" },
-    { name = "fastapi", specifier = ">=0.116,<0.138" },
+    { name = "fastapi", specifier = ">=0.116,<0.139" },
     { name = "fastapi-utils", specifier = ">=0.8,<0.9" },
     { name = "h5py", specifier = ">=3.13,<4" },
     { name = "hypercorn", specifier = ">=0.18,<0.19" },


### PR DESCRIPTION
## Summary

- Adopts RHEL AI midstream versioning per [ADR0170](https://docs.aipcc.redhat.com/adrs/0170-update-tagging-pattern-for-midstream-mirrors/) — versions derived automatically from git tags of the form `v$version+rhaiv.$build`
- Replaces the hardcoded version (`1.0.0rc0`) in three places with a single source of truth: git tags
- Uses `hatch-vcs` (setuptools-scm via hatchling) for dynamic version resolution

### Changes

| File | What |
|---|---|
| `pyproject.toml` | `version` → `dynamic = ["version"]`, add hatch-vcs config, exclude `_version.py` from ruff/pyrefly |
| `src/__init__.py` | Export `__version__` from generated `_version.py` with fallback |
| `src/main.py` | FastAPI metadata uses dynamic `__version__` |
| `.gitignore` | Exclude auto-generated `src/_version.py` |
| `Containerfile` | Generate `_version.py` at build time via `VERSION` build arg; builder stage uses `SETUPTOOLS_SCM_PRETEND_VERSION` and `mkdir -p src` so hatch-vcs hook can write there |
| `build-and-push.yaml` | Sanitize `+` → `-` in OCI image tags, pass `VERSION`/`BUILD_DATE`/`VCS_REF` build args |
| `ci-build.yaml` | Pass `VERSION` build arg for consistency |
| `uv.lock` | Updated to reflect dynamic version metadata |

### Version behavior

| Scenario | `__version__` | Image tag |
|---|---|---|
| Tagged `v0.50.0+rhaiv.1` | `0.50.0+rhaiv.1` | `v0.50.0-rhaiv.1`, `latest` |
| Main push after tag (3 commits) | `0.50.0.post1.dev3+rhaiv.1` | `latest` |
| No tags / no git | `0.0.0.dev0` (fallback) | `latest` |

### Key design decisions

- **`local_scheme = "dirty-tag"`**: preserves the tag's `+rhaiv.N` local version while marking dirty builds. `"no-local-version"` was tested but strips the `+rhaiv.N` entirely.
- **No custom `tag_regex`**: setuptools-scm's default regex correctly handles `+` in tags — it captures the base version and separately preserves the local suffix.
- **OCI tag sanitization**: `+` is illegal in image tags (`[a-zA-Z0-9._-]`), so `v0.50.0+rhaiv.1` → `v0.50.0-rhaiv.1` for image tags while the full version is preserved in OCI labels.
- **Builder stage workaround**: The builder only has `pyproject.toml` (no `src/` or `.git`), so `SETUPTOOLS_SCM_PRETEND_VERSION` bypasses VCS detection and `mkdir -p src` lets the hatch-vcs build hook write `_version.py`. Both are discarded with the builder stage.

## Test plan

- [x] `hatchling version` on dirty tree at tag: `0.50.0.post1.dev0+rhaiv.1.dirty`
- [x] `hatch build --hooks-only` generates correct `src/_version.py`
- [x] `from src import __version__` returns fallback when `_version.py` absent
- [x] `from src import __version__` returns tag version when `_version.py` present
- [x] CI build passes with builder stage workaround
- [x] CI: tag push triggers correct image build with sanitized tag (`v0.30.0-rhaiv.1`)
- [x] Container: `_version.py` exists and `__version__` returns `0.30.0+rhaiv.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)