### PR TITLE
chore(security): enable OpenSSF Scorecard and pin GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,21 @@ updates:
       - trustyai-explainability/reviewers
     reviewers:
       - trustyai-explainability/reviewers
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - trustyai-explainability/reviewers
+    reviewers:
+      - trustyai-explainability/reviewers
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - trustyai-explainability/reviewers
+    reviewers:
+      - trustyai-explainability/reviewers

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -23,7 +23,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set image tags
         id: tags
@@ -74,7 +74,7 @@ jobs:
           done
 
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: 'image'
           image-ref: "${{ vars.QUAY_RELEASE_REPO }}:${{ steps.tags.outputs.primary_tag }}"
@@ -86,7 +86,7 @@ jobs:
           vuln-type: 'os,library'
 
       - name: Update Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'trivy-release-scan'

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -21,13 +21,13 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: mheap/github-action-required-labels@v4
+      - uses: mheap/github-action-required-labels@a5a913cf90303cbc96c2f317edb7b4a6fd182055 # v4
         with:
           mode: minimum
           count: 1
           labels: "ok-to-test, lgtm, approved"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Add expiry label to CI image
         run: |
@@ -46,7 +46,7 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" > /tmp/pr-sha.txt
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ci-build
           path: |

--- a/.github/workflows/ci-publish.yaml
+++ b/.github/workflows/ci-publish.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Set pending status on PR
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -32,7 +32,7 @@ jobs:
             });
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ci-build
           run-id: ${{ github.event.workflow_run.id }}
@@ -93,7 +93,7 @@ jobs:
           create-target-branch-if-needed: 'true'
 
       - name: Find existing comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: fc
         with:
           issue-number: ${{ steps.meta.outputs.pr-number }}
@@ -101,7 +101,7 @@ jobs:
           body-includes: PR image build and manifest generation completed successfully
 
       - name: Post success comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         env:
           IMAGE: quay.io/trustyai/trustyai-service-python-ci
           TAG: ${{ steps.meta.outputs.pr-sha }}
@@ -126,7 +126,7 @@ jobs:
 
       - name: Trivy scan
         continue-on-error: true
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         env:
           IMAGE: quay.io/trustyai/trustyai-service-python-ci
           TAG: ${{ steps.meta.outputs.pr-sha }}
@@ -142,7 +142,7 @@ jobs:
 
       - name: Update Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'trivy-ci-scan'
@@ -150,7 +150,7 @@ jobs:
       - name: Report final status to PR
         if: always()
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const success = '${{ job.status }}' === 'success';

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -19,15 +19,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -43,15 +43,15 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -76,16 +76,16 @@ jobs:
         python-version: ["3.12", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true  # Python 3.14 is pre-release until Oct 2026
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -107,7 +107,7 @@ jobs:
           sudo service mariadb stop || true
 
       - name: Set up MariaDB
-        uses: getong/mariadb-action@v1.11
+        uses: getong/mariadb-action@d6d2ec41fd5588f369be4c9398ce77ee725ca9ea # v1.11
         with:
           mysql user: 'trustyai'
           mysql password: 'trustyai'  # pragma: allowlist secret
@@ -121,7 +121,7 @@ jobs:
         run: uv run pytest tests/ -v --cov=src --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           file: ./coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,34 @@
+name: OpenSSF Scorecard
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '17 7 * * 1'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      - uses: github/codeql-action/upload-sarif@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -22,16 +22,16 @@ jobs:
       checks: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           # uv handles its own caching via setup-uv
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -44,14 +44,14 @@ jobs:
 
       - name: Upload SARIF results to GitHub Security tab
         if: github.ref == 'refs/heads/main'
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
         with:
           sarif_file: results.sarif
           category: bandit-security-scan
         continue-on-error: true
 
       - name: Upload SARIF as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bandit-sarif-results
           path: results.sarif

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 [![Contributing](https://img.shields.io/badge/Contributing-guide-blue)](https://github.com/trustyai-explainability/trustyai-service/blob/main/CONTRIBUTING.md)
 [![CodeRabbit](https://img.shields.io/badge/CodeRabbit-AI%20Reviews-orange?logo=coderabbit)](https://coderabbit.ai)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/trustyai-explainability/trustyai-service/badge)](https://scorecard.dev/viewer/?uri=github.com/trustyai-explainability/trustyai-service)
 
 👋 The TrustyAI Service is intended to be a hub for all kinds of Responsible AI workflows, such as
 explainability, drift, and Large Language Model (LLM) evaluation. Designed as a REST server wrapping

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+### Red Hat Product Security
+
+For vulnerabilities affecting Red Hat OpenShift AI (RHOAI) deployments:
+
+- **Email:** secalert@redhat.com
+- **Web:** https://access.redhat.com/security/team/contact/
+
+### Upstream Project
+
+For vulnerabilities in the upstream open source project:
+
+- **GitHub:** Use [GitHub Security Advisories](https://github.com/trustyai-explainability/trustyai-service/security/advisories/new) to report privately
+
+### Response Timeline
+
+- **Acknowledgement:** Within 3 business days
+- **Initial assessment:** Within 7 business days
+- **Fix timeline:** Depends on severity; critical issues are prioritized
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| main branch | Yes |
+| Released tags | Yes |
+
+## Security Practices
+
+This project employs:
+
+- **Static analysis:** Bandit (Python security linter) and Ruff
+- **Dependency scanning:** Dependabot, Trivy container scanning
+- **Type checking:** Pyrefly
+- **Secret detection:** detect-secrets, gitleaks
+- **Container hardening:** UBI minimal base image, non-root user, FIPS-compatible crypto policy


### PR DESCRIPTION
## Summary
- Add OpenSSF Scorecard GitHub Actions workflow (weekly + on push to main)
- Pin all 13 GitHub Actions dependencies by SHA for supply chain security
- Expand Dependabot config to cover `github-actions` and `docker` ecosystems
- Create SECURITY.md with vulnerability reporting process
- Add OpenSSF Scorecard badge to README

## Motivation
Improve supply chain security posture and gain visibility into areas needing improvement via the [OpenSSF Scorecard](https://scorecard.dev/) framework.

## Test plan
- [ ] All CI workflows pass with SHA-pinned actions
- [ ] Scorecard workflow runs successfully after merge
- [ ] Dependabot starts proposing GitHub Actions version updates
- [ ] OpenSSF badge renders on README

Ref: RHOAIENG-71265

🤖 Generated with [Claude Code](https://claude.com/claude-code)