### PR TITLE
fix(api): align /info endpoint responses with Java service parity

### DIFF
--- a/src/trustyai_service/endpoints/metadata.py
+++ b/src/trustyai_service/endpoints/metadata.py
@@ -2,9 +2,9 @@
 
 import logging
 from http import HTTPStatus
-from typing import Never
+from typing import Annotated, Never
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Body, HTTPException
 from pydantic import BaseModel
 
 from trustyai_service.service.constants import INPUT_SUFFIX, OUTPUT_SUFFIX
@@ -33,6 +33,7 @@ def _build_readable_schema(
     for name, item in schema.items.items():
         items[name] = {
             "type": item.type.value if hasattr(item.type, "value") else str(item.type),
+            "name": item.name,
             "index": item.column_index,
         }
     name_mapping = {
@@ -71,12 +72,6 @@ class DataTagging(BaseModel):
     dataTagging: dict[str, list[list[int]]] = {}
 
 
-class ModelIdRequest(BaseModel):
-    """Request payload containing a model identifier."""
-
-    modelId: str
-
-
 @router.get("/info")
 async def get_service_info() -> dict[str, dict]:
     """Get a comprehensive overview of the model inference datasets collected by TrustyAI.
@@ -99,7 +94,6 @@ async def get_service_info() -> dict[str, dict]:
                 # Get metadata for each model
                 model_metadata = await data_source.get_metadata(model_id)
                 num_observations = await data_source.get_num_observations(model_id)
-                has_inferences = await data_source.has_recorded_inferences(model_id)
 
                 # Get scheduled metrics for this model
                 scheduled_metadata = {}
@@ -153,7 +147,6 @@ async def get_service_info() -> dict[str, dict]:
                 service_metadata[model_id] = {
                     "data": {
                         "observations": num_observations,
-                        "hasRecordedInferences": has_inferences,
                         "inputTensorName": model_metadata.input_tensor_name
                         if model_metadata
                         else "input",
@@ -175,14 +168,15 @@ async def get_service_info() -> dict[str, dict]:
                         if model_metadata
                         else {"items": {}, "nameMapping": {}},
                     },
-                    "metrics": {"scheduledMetadata": scheduled_metadata},
+                    "metrics": {
+                        "scheduledMetadata": {"metricCounts": scheduled_metadata},
+                    },
                 }
 
                 logger.debug(
-                    "Retrieved metadata for model %s: observations=%s, hasInferences=%s",
+                    "Retrieved metadata for model %s: observations=%s",
                     model_id,
                     num_observations,
-                    has_inferences,
                 )
 
             except Exception as e:  # Intentional: per-model errors should not break entire info endpoint
@@ -193,13 +187,14 @@ async def get_service_info() -> dict[str, dict]:
                 service_metadata[model_id] = {
                     "data": {
                         "observations": 0,
-                        "hasRecordedInferences": False,
                         "inputTensorName": "input",
                         "outputTensorName": "output",
                         "inputSchema": {"items": {}, "nameMapping": {}},
                         "outputSchema": {"items": {}, "nameMapping": {}},
                     },
-                    "metrics": {"scheduledMetadata": {}},
+                    "metrics": {
+                        "scheduledMetadata": {"metricCounts": {}},
+                    },
                     "error": str(e),
                 }
 
@@ -376,32 +371,42 @@ async def apply_column_names(name_mapping: NameMapping) -> dict[str, str]:
         )
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=error_msg)
 
-    try:
-        # Apply input mappings if provided and dataset exists
-        if name_mapping.inputMapping and input_exists:
-            logger.info(
-                "Applying input mappings for model %s: %s",
-                model_id,
-                name_mapping.inputMapping,
+    # Validate column names before applying
+    if name_mapping.inputMapping and input_exists:
+        original_input = await storage_interface.get_original_column_names(
+            input_dataset_name
+        )
+        invalid = set(name_mapping.inputMapping.keys()) - set(original_input)
+        if invalid:
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST,
+                detail=f"No feature found with name={', '.join(sorted(invalid))}. "
+                f"Valid features: {original_input}",
             )
+
+    if name_mapping.outputMapping and output_exists:
+        original_output = await storage_interface.get_original_column_names(
+            output_dataset_name
+        )
+        invalid = set(name_mapping.outputMapping.keys()) - set(original_output)
+        if invalid:
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST,
+                detail=f"No output found with name={', '.join(sorted(invalid))}. "
+                f"Valid outputs: {original_output}",
+            )
+
+    try:
+        if name_mapping.inputMapping and input_exists:
             await storage_interface.apply_name_mapping(
                 input_dataset_name, name_mapping.inputMapping
             )
 
-        # Apply output mappings if provided and dataset exists
         if name_mapping.outputMapping and output_exists:
-            logger.info(
-                "Applying output mappings for model %s: %s",
-                model_id,
-                name_mapping.outputMapping,
-            )
             await storage_interface.apply_name_mapping(
                 output_dataset_name, name_mapping.outputMapping
             )
 
-    except HTTPException:
-        # Re-raise HTTP exceptions without wrapping
-        raise
     except Exception as e:  # Broad catch intentional: endpoint catch-all for unknown application errors
         logger.exception("Error applying column names")
         raise HTTPException(
@@ -414,9 +419,10 @@ async def apply_column_names(name_mapping: NameMapping) -> dict[str, str]:
 
 
 @router.delete("/info/names")
-async def remove_column_names(request: ModelIdRequest) -> dict[str, str]:
+async def remove_column_names(
+    model_id: Annotated[str, Body(embed=False)],
+) -> dict[str, str]:
     """Remove any column names that have been applied to a particular inference."""
-    model_id = request.modelId
     logger.info("Removing column names for model: %s", model_id)
 
     input_dataset_name = model_id + INPUT_SUFFIX

--- a/tests/endpoints/test_metadata_info.py
+++ b/tests/endpoints/test_metadata_info.py
@@ -18,7 +18,7 @@ class TestBuildReadableSchema:
     """Tests for _build_readable_schema helper."""
 
     def test_converts_schema_with_items(self) -> None:
-        """Schema items are serialized with type and index."""
+        """Schema items are serialized with type, name, and index."""
         schema = Schema(
             items={
                 "col1": SchemaItem(DataType.DOUBLE, "col1", 0),
@@ -27,8 +27,16 @@ class TestBuildReadableSchema:
         )
         result = _build_readable_schema(schema, ["col1", "col2"], ["col1", "col2"])
 
-        assert result["items"]["col1"] == {"type": "DOUBLE", "index": 0}
-        assert result["items"]["col2"] == {"type": "INT32", "index": 1}
+        assert result["items"]["col1"] == {
+            "type": "DOUBLE",
+            "name": "col1",
+            "index": 0,
+        }
+        assert result["items"]["col2"] == {
+            "type": "INT32",
+            "name": "col2",
+            "index": 1,
+        }
         assert result["nameMapping"] == {}
 
     def test_includes_name_mapping(self) -> None:
@@ -57,7 +65,7 @@ class TestInfoEndpointSchema:
     async def test_info_includes_schemas(
         self, mock_get_ds: MagicMock, mock_storage: MagicMock
     ) -> None:
-        """The /info response includes inputSchema and outputSchema."""
+        """The /info response includes inputSchema and outputSchema with name field."""
         mock_ds = MagicMock()
         mock_ds.get_known_models = AsyncMock(return_value={"test-model"})
 
@@ -72,7 +80,6 @@ class TestInfoEndpointSchema:
         )
         mock_ds.get_metadata = AsyncMock(return_value=mock_metadata)
         mock_ds.get_num_observations = AsyncMock(return_value=100)
-        mock_ds.has_recorded_inferences = AsyncMock(return_value=True)
         mock_get_ds.return_value = mock_ds
 
         mock_storage.get_original_column_names = AsyncMock(
@@ -85,9 +92,21 @@ class TestInfoEndpointSchema:
         response = client.get("/info")
 
         assert response.status_code == 200  # noqa: PLR2004
-        data = response.json()["test-model"]["data"]
+        model_data = response.json()["test-model"]
+        data = model_data["data"]
+
         assert "inputSchema" in data
         assert "outputSchema" in data
-        assert data["inputSchema"]["items"]["f1"] == {"type": "DOUBLE", "index": 0}
+        assert data["inputSchema"]["items"]["f1"] == {
+            "type": "DOUBLE",
+            "name": "f1",
+            "index": 0,
+        }
         assert data["inputSchema"]["nameMapping"] == {"f1": "Feature One"}
         assert data["outputSchema"]["nameMapping"] == {}
+
+        assert "hasRecordedInferences" not in data
+
+        metrics = model_data["metrics"]
+        assert "scheduledMetadata" in metrics
+        assert "metricCounts" in metrics["scheduledMetadata"]

--- a/tests/endpoints/test_name_mapping.py
+++ b/tests/endpoints/test_name_mapping.py
@@ -1,0 +1,133 @@
+"""Tests for POST /info/names and DELETE /info/names endpoints."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trustyai_service.main import app
+
+client = TestClient(app)
+
+
+class TestApplyColumnNames:
+    """Tests for POST /info/names endpoint."""
+
+    @patch("trustyai_service.endpoints.metadata.storage_interface")
+    @pytest.mark.asyncio
+    async def test_apply_valid_mapping(self, mock_storage: MagicMock) -> None:
+        """Valid input/output mappings are applied successfully."""
+        mock_storage.dataset_exists = AsyncMock(return_value=True)
+        mock_storage.get_original_column_names = AsyncMock(
+            side_effect=lambda ds: ["f1", "f2"] if "inputs" in ds else ["out1"]
+        )
+        mock_storage.apply_name_mapping = AsyncMock()
+
+        response = client.post(
+            "/info/names",
+            json={
+                "modelId": "test-model",
+                "inputMapping": {"f1": "Feature One"},
+                "outputMapping": {"out1": "Output One"},
+            },
+        )
+
+        assert response.status_code == 200  # noqa: PLR2004
+        assert "successfully applied" in response.json()["message"]
+        assert mock_storage.apply_name_mapping.call_count == 2  # noqa: PLR2004
+
+    @patch("trustyai_service.endpoints.metadata.storage_interface")
+    @pytest.mark.asyncio
+    async def test_apply_invalid_input_column(self, mock_storage: MagicMock) -> None:
+        """Mapping with non-existent input column returns 400."""
+        mock_storage.dataset_exists = AsyncMock(return_value=True)
+        mock_storage.get_original_column_names = AsyncMock(return_value=["f1", "f2"])
+
+        response = client.post(
+            "/info/names",
+            json={
+                "modelId": "test-model",
+                "inputMapping": {"nonexistent": "Friendly"},
+            },
+        )
+
+        assert response.status_code == 400  # noqa: PLR2004
+        assert "No feature found" in response.json()["detail"]
+        assert "nonexistent" in response.json()["detail"]
+        mock_storage.apply_name_mapping.assert_not_called()
+
+    @patch("trustyai_service.endpoints.metadata.storage_interface")
+    @pytest.mark.asyncio
+    async def test_apply_invalid_output_column(self, mock_storage: MagicMock) -> None:
+        """Mapping with non-existent output column returns 400."""
+        mock_storage.dataset_exists = AsyncMock(return_value=True)
+        mock_storage.get_original_column_names = AsyncMock(
+            side_effect=lambda ds: ["f1"] if "inputs" in ds else ["out1"]
+        )
+
+        response = client.post(
+            "/info/names",
+            json={
+                "modelId": "test-model",
+                "outputMapping": {"bad_col": "Friendly"},
+            },
+        )
+
+        assert response.status_code == 400  # noqa: PLR2004
+        assert "No output found" in response.json()["detail"]
+        assert "bad_col" in response.json()["detail"]
+
+    @patch("trustyai_service.endpoints.metadata.storage_interface")
+    @pytest.mark.asyncio
+    async def test_apply_model_not_found(self, mock_storage: MagicMock) -> None:
+        """Mapping for unknown model returns 400."""
+        mock_storage.dataset_exists = AsyncMock(return_value=False)
+
+        response = client.post(
+            "/info/names",
+            json={
+                "modelId": "unknown-model",
+                "inputMapping": {"f1": "Friendly"},
+            },
+        )
+
+        assert response.status_code == 400  # noqa: PLR2004
+        assert "No metadata found" in response.json()["detail"]
+
+
+class TestRemoveColumnNames:
+    """Tests for DELETE /info/names endpoint."""
+
+    @patch("trustyai_service.endpoints.metadata.storage_interface")
+    @pytest.mark.asyncio
+    async def test_delete_mapping_success(self, mock_storage: MagicMock) -> None:
+        """Clearing name mappings succeeds with plain string body."""
+        mock_storage.dataset_exists = AsyncMock(return_value=True)
+        mock_storage.clear_name_mapping = AsyncMock()
+
+        response = client.request(
+            "DELETE",
+            "/info/names",
+            content='"test-model"',
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 200  # noqa: PLR2004
+        assert "successfully cleared" in response.json()["message"]
+        assert mock_storage.clear_name_mapping.call_count == 2  # noqa: PLR2004
+
+    @patch("trustyai_service.endpoints.metadata.storage_interface")
+    @pytest.mark.asyncio
+    async def test_delete_model_not_found(self, mock_storage: MagicMock) -> None:
+        """Clearing mappings for unknown model returns 400."""
+        mock_storage.dataset_exists = AsyncMock(return_value=False)
+
+        response = client.request(
+            "DELETE",
+            "/info/names",
+            content='"unknown-model"',
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 400  # noqa: PLR2004
+        assert "No metadata found" in response.json()["detail"]


### PR DESCRIPTION
## Summary

Fixes parity gaps between the Python and Java `/info` endpoint family, identified in the [parity analysis](notebooks/info-endpoint-parity-analysis.md). Covers RHOAIENG-21049.

### GET /info
- Add `name` field to schema items (matches Java's `ReadableSchemaItem`)
- Wrap `scheduledMetadata` under `metricCounts` key (matches Java's `ServiceMetricsScheduledMetadata`)
- Remove `hasRecordedInferences` field (not present in Java response)

### POST /info/names
- Add column name validation matching Java's `@ValidNameMappingRequest` — reject mappings with non-existent column names (400 with descriptive error listing valid columns)

### DELETE /info/names
- Accept plain string body instead of JSON object (matches Java's `clearNameMappings` which takes a raw `String modelId`)
- Remove unused `ModelIdRequest` class

### Tests
- Update `test_metadata_info.py` for new schema item format and `metricCounts` wrapper
- Add `test_name_mapping.py` with 6 tests covering POST/DELETE validation

## Test plan
- [x] `uv run pytest tests/endpoints/test_metadata_info.py tests/endpoints/test_name_mapping.py -v` — 10 passed
- [x] `uv run pytest tests/ -v -k "not maria"` — 578 passed, 0 failed
- [x] CI: tests pass on Python 3.12 and 3.14
- [x] CI: lint, type-check, bandit all pass

Ref: RHOAIENG-21049

🤖 Generated with [Claude Code](https://claude.com/claude-code)