### PR TITLE
test(fairness): add DIR and SPD endpoint integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ ignore = [
 "tests/**" = ["S101", "PT019", "SLF001"]
 "tests/core/metrics/test_fairness.py" = ["N803", "N806"]
 "tests/endpoints/metrics/drift/factory.py" = ["PLR0913", "C901", "PLR0915"]
+"tests/endpoints/metrics/fairness/group/factory.py" = ["PLR0913", "PLC0415"]
 "tests/endpoints/test_upload_endpoint_maria.py" = ["S105"]
 "tests/endpoints/test_upload_endpoint_pvc.py" = ["PLR0913"]
 "tests/service/data/test_utils.py" = ["PLR0913", "UP037"]  # UP037: Keep quoted annotations for optional protobuf imports

--- a/src/trustyai_service/endpoints/metrics/fairness/group/dir.py
+++ b/src/trustyai_service/endpoints/metrics/fairness/group/dir.py
@@ -187,7 +187,7 @@ async def get_dir_definition() -> dict[str, str]:
 @router.post("/metrics/group/fairness/dir/definition")
 async def interpret_dir_value(request: GroupDefinitionRequest) -> dict[str, str]:
     """Provide a specific, plain-english interpretation of a specific value of DIR metric."""
-    logger.info("Interpreting DIR value for model: %s", request.modelId)
+    logger.info("Interpreting DIR value for model: %s", request.model_id)
     raise HTTPException(
         status_code=HTTPStatus.NOT_IMPLEMENTED,
         detail="DIR value interpretation is not yet implemented",

--- a/src/trustyai_service/endpoints/metrics/fairness/group/spd.py
+++ b/src/trustyai_service/endpoints/metrics/fairness/group/spd.py
@@ -182,7 +182,7 @@ async def get_spd_definition() -> dict[str, str]:
 @router.post("/metrics/group/fairness/spd/definition")
 async def interpret_spd_value(request: GroupDefinitionRequest) -> dict[str, str]:
     """Provide a specific, plain-english interpretation of a specific value of SPD metric."""
-    logger.info("Interpreting SPD value for model: %s", request.modelId)
+    logger.info("Interpreting SPD value for model: %s", request.model_id)
     raise HTTPException(
         status_code=HTTPStatus.NOT_IMPLEMENTED,
         detail="SPD value interpretation is not yet implemented",

--- a/tests/endpoints/metrics/fairness/__init__.py
+++ b/tests/endpoints/metrics/fairness/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for fairness metric endpoints."""

--- a/tests/endpoints/metrics/fairness/group/__init__.py
+++ b/tests/endpoints/metrics/fairness/group/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for group fairness metric endpoints."""

--- a/tests/endpoints/metrics/fairness/group/factory.py
+++ b/tests/endpoints/metrics/fairness/group/factory.py
@@ -1,0 +1,987 @@
+"""Unified test factories for group fairness metric endpoints (DIR, SPD).
+
+This module provides factory functions to create common tests that apply to all
+group fairness metric endpoints. Follows the same pattern as the drift metric
+test factory in ``tests/endpoints/metrics/drift/factory.py``.
+
+All group fairness endpoints share a common structure:
+
+- POST /metrics/group/fairness/{metric}           - Compute metric
+- GET  /metrics/group/fairness/{metric}/definition - Get metric definition
+- POST /metrics/group/fairness/{metric}/definition - Interpret specific value
+- POST /metrics/group/fairness/{metric}/request    - Schedule recurring computation
+- DELETE /metrics/group/fairness/{metric}/request  - Delete scheduled computation
+- GET  /metrics/group/fairness/{metric}/requests   - List scheduled computations
+
+Common request fields (camelCase, matching the Java API):
+
+- modelId: Model identifier
+- protectedAttribute: Name of the demographic feature column
+- outcomeName: Name of the outcome/prediction column
+- privilegedAttribute: Value(s) identifying the privileged group
+- unprivilegedAttribute: Value(s) identifying the unprivileged group
+- favorableOutcome: Value(s) considered a positive/favorable outcome
+- batchSize: Optional batch size for data retrieval
+- thresholdDelta: Optional threshold delta for fairness bounds
+"""
+
+from collections.abc import Callable
+from http import HTTPStatus
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import numpy as np
+import pandas as pd
+from fastapi.testclient import TestClient
+
+# ============================================================================
+# Sample data helpers
+# ============================================================================
+
+
+def _create_fairness_dataframe(
+    protected_attr: str = "gender",
+    outcome_name: str = "income",
+    n_samples: int = 200,
+) -> pd.DataFrame:
+    """Create a sample Pandas DataFrame suitable for fairness metric testing.
+
+    Produces a balanced dataset with two demographic groups and binary outcomes
+    designed so that the privileged group has a higher favorable-outcome rate,
+    making SPD != 0 and DIR != 1.
+
+    Args:
+        protected_attr: Column name for the protected attribute.
+        outcome_name: Column name for the outcome variable.
+        n_samples: Total number of rows (split evenly between groups).
+
+    Returns:
+        Pandas DataFrame with ``protected_attr`` and ``outcome_name`` columns.
+
+    """
+    rng = np.random.default_rng(42)
+    half = n_samples // 2
+
+    # Privileged group: ~80% favorable outcome rate
+    priv_outcomes = rng.choice([1, 0], size=half, p=[0.8, 0.2])
+    # Unprivileged group: ~50% favorable outcome rate
+    unpriv_outcomes = rng.choice([1, 0], size=half, p=[0.5, 0.5])
+
+    return pd.DataFrame(
+        {
+            protected_attr: ["male"] * half + ["female"] * half,
+            outcome_name: np.concatenate([priv_outcomes, unpriv_outcomes]),
+        }
+    )
+
+
+# ============================================================================
+# Standard request payload
+# ============================================================================
+
+
+def _base_request_payload() -> dict[str, Any]:
+    """Return a minimal valid request payload for group fairness endpoints."""
+    return {
+        "modelId": "test-model",
+        "protectedAttribute": "gender",
+        "outcomeName": "income",
+        "privilegedAttribute": "male",
+        "unprivilegedAttribute": "female",
+        "favorableOutcome": 1,
+        "batchSize": 100,
+    }
+
+
+# ============================================================================
+# Success-case factories
+# ============================================================================
+
+
+def make_compute_endpoint_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+    request_payload: dict[str, Any],
+    expected_response_keys: list[str],
+) -> Callable[[], None]:
+    """Create a test that verifies the compute endpoint returns a valid response.
+
+    Args:
+        metric_name: Human-readable metric name for assertion messages.
+        module_path: Dotted module path for ``unittest.mock.patch``.
+        endpoint_path: HTTP path (e.g. ``/metrics/group/fairness/dir``).
+        client: ``TestClient`` wired to the metric router.
+        request_payload: JSON body to POST.
+        expected_response_keys: Top-level keys that must appear in the response.
+
+    Returns:
+        A test callable (bound to ``self`` when used as a class attribute).
+
+    """
+
+    @patch(f"{module_path}.get_data_source")
+    def test_impl(_: object, mock_ds: MagicMock) -> None:
+        sample_df = _create_fairness_dataframe(
+            protected_attr=request_payload.get("protectedAttribute", "gender"),
+            outcome_name=request_payload.get("outcomeName", "income"),
+        )
+        mock_data_source = MagicMock()
+        mock_data_source.get_organic_dataframe = AsyncMock(return_value=sample_df)
+        mock_ds.return_value = mock_data_source
+
+        response = client.post(endpoint_path, json=request_payload)
+
+        assert response.status_code == HTTPStatus.OK, (
+            f"{metric_name} compute failed: {response.text}"
+        )
+        data = response.json()
+        for key in expected_response_keys:
+            assert key in data, f"Missing key '{key}' in {metric_name} response"
+        # value must be numeric
+        assert isinstance(data["value"], (int, float))
+        # thresholds sub-object must have bounds
+        assert "lowerBound" in data["thresholds"]
+        assert "upperBound" in data["thresholds"]
+        assert "outsideBounds" in data["thresholds"]
+
+    return test_impl
+
+
+def make_definition_endpoint_test(
+    metric_name: str,
+    endpoint_path: str,
+    client: TestClient,
+    expected_name: str,
+) -> Callable[[Any], None]:
+    """Create a test that verifies the GET definition endpoint."""
+
+    def test_impl(_: object) -> None:
+        response = client.get(endpoint_path)
+
+        assert response.status_code == HTTPStatus.OK, (
+            f"{metric_name} definition failed: {response.text}"
+        )
+        data = response.json()
+        assert "name" in data
+        assert "description" in data
+        assert expected_name.lower() in data["name"].lower(), (
+            f"Expected '{expected_name}' in name, got: {data['name']}"
+        )
+        assert len(data["description"]) > 0
+
+    return test_impl
+
+
+def make_interpret_value_not_implemented_test(
+    metric_name: str,
+    endpoint_path: str,
+    client: TestClient,
+) -> Callable[[Any], None]:
+    """Create a test that verifies the POST definition (interpret) endpoint returns 501."""
+
+    def test_impl(_: object) -> None:
+        payload = {
+            "modelId": "test-model",
+            "protectedAttribute": "gender",
+            "outcomeName": "income",
+            "privilegedAttribute": "male",
+            "unprivilegedAttribute": "female",
+            "favorableOutcome": 1,
+            "metricValue": {"value": 0.85},
+        }
+        response = client.post(endpoint_path, json=payload)
+
+        assert response.status_code == HTTPStatus.NOT_IMPLEMENTED, (
+            f"{metric_name} interpret should return 501, got "
+            f"{response.status_code}: {response.text}"
+        )
+        data = response.json()
+        assert "detail" in data
+        assert "not yet implemented" in data["detail"].lower()
+
+    return test_impl
+
+
+def make_schedule_endpoint_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+    request_payload: dict[str, Any],
+) -> Callable[[], None]:
+    """Create a test that verifies the schedule endpoint returns a requestId."""
+
+    @patch(f"{module_path}.get_prometheus_scheduler")
+    def test_impl(_: object, mock_sched_fn: MagicMock) -> None:
+        mock_sched = MagicMock()
+        mock_sched.register = AsyncMock(return_value=None)
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.post(endpoint_path, json=request_payload)
+
+        assert response.status_code == HTTPStatus.OK, (
+            f"{metric_name} schedule failed: {response.text}"
+        )
+        data = response.json()
+        assert "requestId" in data
+        request_id = data["requestId"]
+        assert isinstance(request_id, str)
+        assert "-" in request_id  # basic UUID shape check
+
+    return test_impl
+
+
+def make_delete_schedule_endpoint_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+) -> Callable[[], None]:
+    """Create a test that verifies the delete-schedule endpoint."""
+
+    @patch(f"{module_path}.get_prometheus_scheduler")
+    def test_impl(_: object, mock_sched_fn: MagicMock) -> None:
+        mock_sched = MagicMock()
+        mock_sched.delete = AsyncMock(return_value=None)
+        mock_sched_fn.return_value = mock_sched
+
+        test_uuid = "123e4567-e89b-12d3-a456-426614174000"
+        response = client.request(
+            "DELETE", endpoint_path, json={"requestId": test_uuid}
+        )
+
+        assert response.status_code == HTTPStatus.OK, (
+            f"{metric_name} delete schedule failed: {response.text}"
+        )
+        data = response.json()
+        assert data["status"] == "success"
+
+    return test_impl
+
+
+def make_list_requests_endpoint_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+) -> Callable[[], None]:
+    """Create a test that verifies the list-requests endpoint (empty case)."""
+
+    @patch(f"{module_path}.get_prometheus_scheduler")
+    def test_impl(_: object, mock_sched_fn: MagicMock) -> None:
+        mock_sched = MagicMock()
+        mock_sched.get_requests = MagicMock(return_value={})
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.get(endpoint_path)
+
+        assert response.status_code == HTTPStatus.OK, (
+            f"{metric_name} list requests failed: {response.text}"
+        )
+        data = response.json()
+        assert "requests" in data
+        assert isinstance(data["requests"], list)
+
+    return test_impl
+
+
+# ============================================================================
+# Edge-case factories
+# ============================================================================
+
+
+def make_list_requests_with_data_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+    num_requests: int = 2,
+) -> Callable[[], None]:
+    """Create a test that verifies the list endpoint with populated requests."""
+
+    @patch(f"{module_path}.get_prometheus_scheduler")
+    def test_impl(_: object, mock_sched_fn: MagicMock) -> None:
+        mock_requests: dict[Any, Any] = {}
+        for i in range(num_requests):
+            request_id = uuid4()
+            mock_request = MagicMock()
+            mock_request.model_id = f"test-model-{i}"
+            mock_request.batch_size = 100 + i * 10
+            mock_request.protected_attribute = "gender"
+            mock_request.outcome_name = "income"
+            mock_requests[request_id] = mock_request
+
+        mock_sched = MagicMock()
+        mock_sched.get_requests = MagicMock(return_value=mock_requests)
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.get(endpoint_path)
+
+        assert response.status_code == HTTPStatus.OK, (
+            f"{metric_name} list with data failed: {response.text}"
+        )
+        data = response.json()
+        assert len(data["requests"]) == num_requests
+
+        for req in data["requests"]:
+            assert "requestId" in req
+            assert "modelId" in req
+            assert "metricName" in req
+            assert "batchSize" in req
+            assert "protectedAttribute" in req
+            assert "outcomeName" in req
+
+    return test_impl
+
+
+def make_list_requests_with_malformed_data_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+    num_valid_requests: int = 2,
+    num_malformed_requests: int = 2,
+) -> Callable[[], None]:
+    """Create a test that verifies malformed requests are filtered out."""
+
+    @patch(f"{module_path}.get_prometheus_scheduler")
+    def test_impl(_: object, mock_sched_fn: MagicMock) -> None:
+        mock_requests: dict[Any, Any] = {}
+
+        # Valid requests
+        for i in range(num_valid_requests):
+            request_id = uuid4()
+            mock_request = MagicMock()
+            mock_request.model_id = f"test-model-{i}"
+            mock_request.batch_size = 100
+            mock_request.protected_attribute = "gender"
+            mock_request.outcome_name = "income"
+            mock_requests[request_id] = mock_request
+
+        # Malformed requests: missing required attributes
+        malformed_scenarios: list[dict[str, Any]] = [
+            {
+                "batch_size": 100,
+                "protected_attribute": "gender",
+                "outcome_name": "income",
+            },  # missing model_id
+            {
+                "model_id": "model",
+                "protected_attribute": "gender",
+                "outcome_name": "income",
+            },  # missing batch_size
+            {
+                "model_id": "model",
+                "batch_size": 100,
+                "outcome_name": "income",
+            },  # missing protected_attribute
+            {
+                "model_id": "model",
+                "batch_size": 100,
+                "protected_attribute": "gender",
+            },  # missing outcome_name
+        ]
+
+        for i in range(num_malformed_requests):
+            request_id = uuid4()
+            mock_request = MagicMock(spec=[])  # no attributes
+            scenario = malformed_scenarios[i % len(malformed_scenarios)]
+            for attr, value in scenario.items():
+                setattr(mock_request, attr, value)
+            mock_requests[request_id] = mock_request
+
+        mock_sched = MagicMock()
+        mock_sched.get_requests = MagicMock(return_value=mock_requests)
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.get(endpoint_path)
+
+        assert response.status_code == HTTPStatus.OK, (
+            f"{metric_name} list should handle malformed requests, "
+            f"got {response.status_code}: {response.text}"
+        )
+        data = response.json()
+        assert len(data["requests"]) == num_valid_requests, (
+            f"{metric_name} should return {num_valid_requests} valid requests "
+            f"(filtering out {num_malformed_requests} malformed), "
+            f"got {len(data['requests'])}"
+        )
+
+        for req in data["requests"]:
+            assert req["modelId"].startswith("test-model-")
+
+    return test_impl
+
+
+# ============================================================================
+# Error-case factories
+# ============================================================================
+
+
+def make_compute_empty_data_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+    request_payload: dict[str, Any],
+) -> Callable[[], None]:
+    """Create a test for compute endpoint when no data exists for the model."""
+
+    @patch(f"{module_path}.get_data_source")
+    def test_impl(_: object, mock_ds: MagicMock) -> None:
+        mock_data_source = MagicMock()
+        mock_data_source.get_organic_dataframe = AsyncMock(return_value=pd.DataFrame())
+        mock_ds.return_value = mock_data_source
+
+        response = client.post(endpoint_path, json=request_payload)
+
+        assert response.status_code == HTTPStatus.NOT_FOUND, (
+            f"{metric_name} should return 404 for empty data, got "
+            f"{response.status_code}: {response.text}"
+        )
+        data = response.json()
+        assert "detail" in data
+        assert "no data found" in data["detail"].lower()
+
+    return test_impl
+
+
+def make_compute_generic_exception_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+    request_payload: dict[str, Any],
+) -> Callable[[], None]:
+    """Create a test for compute endpoint catch-all exception handler."""
+
+    @patch(f"{module_path}.get_data_source")
+    def test_impl(_: object, mock_ds: MagicMock) -> None:
+        mock_data_source = MagicMock()
+        mock_data_source.get_organic_dataframe = AsyncMock(
+            side_effect=RuntimeError("Unexpected database error"),
+        )
+        mock_ds.return_value = mock_data_source
+
+        response = client.post(endpoint_path, json=request_payload)
+
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR, (
+            f"{metric_name} should return 500 on unexpected exception"
+        )
+        data = response.json()
+        assert "detail" in data
+
+    return test_impl
+
+
+def make_compute_endpoint_validation_error_test(
+    metric_name: str,
+    endpoint_path: str,
+    client: TestClient,
+    request_payload: dict[str, Any],
+    expected_status_code: int,
+    expected_error_substring: str,
+) -> Callable[[Any], None]:
+    """Create a test for request validation errors (422)."""
+
+    def test_impl(_: object) -> None:
+        response = client.post(endpoint_path, json=request_payload)
+
+        assert response.status_code == expected_status_code, (
+            f"{metric_name} should return {expected_status_code}, got "
+            f"{response.status_code}: {response.text}"
+        )
+        data = response.json()
+        assert "detail" in data
+
+        detail = data["detail"]
+        if isinstance(detail, list):
+            # Include both msg and loc for 422 validation errors so
+            # assertions can match on field names (e.g. "modelId").
+            parts: list[str] = []
+            for err in detail:
+                if isinstance(err, dict):
+                    parts.append(str(err.get("msg", "")))
+                    loc = err.get("loc", [])
+                    parts.extend(str(segment) for segment in loc)
+                else:
+                    parts.append(str(err))
+            detail_text = " ".join(parts)
+        else:
+            detail_text = str(detail)
+
+        assert expected_error_substring.lower() in detail_text.lower(), (
+            f"Expected '{expected_error_substring}' in {metric_name} error, "
+            f"got: {detail}"
+        )
+
+    return test_impl
+
+
+def make_delete_invalid_uuid_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+) -> Callable[[], None]:
+    """Create a test for DELETE with an invalid UUID."""
+
+    @patch(f"{module_path}.get_prometheus_scheduler")
+    def test_impl(_: object, mock_sched_fn: MagicMock) -> None:
+        mock_sched = MagicMock()
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.request(
+            "DELETE",
+            endpoint_path,
+            json={"requestId": "not-a-valid-uuid"},
+        )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST, (
+            f"{metric_name} delete should return 400 for invalid UUID"
+        )
+        data = response.json()
+        assert "detail" in data
+        assert "invalid request id" in data["detail"].lower()
+
+    return test_impl
+
+
+def make_schedule_scheduler_unavailable_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+    request_payload: dict[str, Any],
+) -> Callable[[], None]:
+    """Create a test for schedule endpoint when scheduler is None."""
+
+    @patch(f"{module_path}.get_prometheus_scheduler")
+    def test_impl(_: object, mock_sched_fn: MagicMock) -> None:
+        mock_sched_fn.return_value = None
+
+        response = client.post(endpoint_path, json=request_payload)
+
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR, (
+            f"{metric_name} schedule should return 500 when scheduler unavailable"
+        )
+        data = response.json()
+        assert "detail" in data
+        assert "scheduler not available" in data["detail"].lower()
+
+    return test_impl
+
+
+def make_schedule_register_exception_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+    request_payload: dict[str, Any],
+) -> Callable[[], None]:
+    """Create a test for schedule endpoint when register() raises."""
+
+    @patch(f"{module_path}.get_prometheus_scheduler")
+    def test_impl(_: object, mock_sched_fn: MagicMock) -> None:
+        mock_sched = MagicMock()
+        mock_sched.register = AsyncMock(
+            side_effect=Exception("Database connection failed")
+        )
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.post(endpoint_path, json=request_payload)
+
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR, (
+            f"{metric_name} schedule should return 500 on register exception"
+        )
+        data = response.json()
+        assert "detail" in data
+        assert "error scheduling metric" in data["detail"].lower()
+
+    return test_impl
+
+
+def make_delete_scheduler_unavailable_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+) -> Callable[[], None]:
+    """Create a test for DELETE when scheduler is None."""
+
+    @patch(f"{module_path}.get_prometheus_scheduler")
+    def test_impl(_: object, mock_sched_fn: MagicMock) -> None:
+        mock_sched_fn.return_value = None
+
+        test_uuid = "123e4567-e89b-12d3-a456-426614174000"
+        response = client.request(
+            "DELETE", endpoint_path, json={"requestId": test_uuid}
+        )
+
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR, (
+            f"{metric_name} delete should return 500 when scheduler unavailable"
+        )
+        data = response.json()
+        assert "detail" in data
+        assert "scheduler not available" in data["detail"].lower()
+
+    return test_impl
+
+
+def make_delete_exception_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+) -> Callable[[], None]:
+    """Create a test for DELETE when scheduler.delete() raises."""
+
+    @patch(f"{module_path}.get_prometheus_scheduler")
+    def test_impl(_: object, mock_sched_fn: MagicMock) -> None:
+        mock_sched = MagicMock()
+        mock_sched.delete = AsyncMock(
+            side_effect=Exception("Database connection failed")
+        )
+        mock_sched_fn.return_value = mock_sched
+
+        test_uuid = "123e4567-e89b-12d3-a456-426614174000"
+        response = client.request(
+            "DELETE", endpoint_path, json={"requestId": test_uuid}
+        )
+
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR, (
+            f"{metric_name} delete should return 500 on exception"
+        )
+        data = response.json()
+        assert "detail" in data
+        assert "error deleting schedule" in data["detail"].lower()
+
+    return test_impl
+
+
+def make_list_scheduler_unavailable_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+) -> Callable[[], None]:
+    """Create a test for list endpoint when scheduler is None."""
+
+    @patch(f"{module_path}.get_prometheus_scheduler")
+    def test_impl(_: object, mock_sched_fn: MagicMock) -> None:
+        mock_sched_fn.return_value = None
+
+        response = client.get(endpoint_path)
+
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR, (
+            f"{metric_name} list should return 500 when scheduler unavailable"
+        )
+        data = response.json()
+        assert "detail" in data
+        assert "scheduler not available" in data["detail"].lower()
+
+    return test_impl
+
+
+def make_list_exception_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+) -> Callable[[], None]:
+    """Create a test for list endpoint catch-all exception handler."""
+
+    @patch(f"{module_path}.get_prometheus_scheduler")
+    def test_impl(_: object, mock_sched_fn: MagicMock) -> None:
+        mock_sched = MagicMock()
+        mock_sched.get_requests = MagicMock(
+            side_effect=Exception("Database connection failed"),
+        )
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.get(endpoint_path)
+
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR, (
+            f"{metric_name} list should return 500 on exception"
+        )
+        data = response.json()
+        assert "detail" in data
+        assert "error listing requests" in data["detail"].lower()
+
+    return test_impl
+
+
+# ============================================================================
+# Deprecated endpoint factories
+# ============================================================================
+
+
+def make_deprecated_compute_test(
+    metric_name: str,
+    module_path: str,
+    deprecated_path: str,
+    client: TestClient,
+    request_payload: dict[str, Any],
+    expected_response_keys: list[str],
+) -> Callable[[], None]:
+    """Create a test for a deprecated compute endpoint."""
+
+    @patch(f"{module_path}.get_data_source")
+    def test_impl(_: object, mock_ds: MagicMock) -> None:
+        sample_df = _create_fairness_dataframe(
+            protected_attr=request_payload.get("protectedAttribute", "gender"),
+            outcome_name=request_payload.get("outcomeName", "income"),
+        )
+        mock_data_source = MagicMock()
+        mock_data_source.get_organic_dataframe = AsyncMock(return_value=sample_df)
+        mock_ds.return_value = mock_data_source
+
+        response = client.post(deprecated_path, json=request_payload)
+
+        assert response.status_code == HTTPStatus.OK, (
+            f"Deprecated {metric_name} compute failed: {response.text}"
+        )
+        data = response.json()
+        for key in expected_response_keys:
+            assert key in data, f"Missing '{key}' in deprecated {metric_name} response"
+
+    return test_impl
+
+
+def make_deprecated_definition_test(
+    metric_name: str,
+    deprecated_path: str,
+    client: TestClient,
+    expected_name_substring: str,
+) -> Callable[[Any], None]:
+    """Create a test for a deprecated GET definition endpoint."""
+
+    def test_impl(_: object) -> None:
+        response = client.get(deprecated_path)
+
+        assert response.status_code == HTTPStatus.OK, (
+            f"Deprecated {metric_name} definition failed: {response.text}"
+        )
+        data = response.json()
+        assert "name" in data
+        assert "description" in data
+        assert expected_name_substring.lower() in data["name"].lower()
+
+    return test_impl
+
+
+def make_deprecated_interpret_test(
+    metric_name: str,
+    deprecated_path: str,
+    client: TestClient,
+) -> Callable[[Any], None]:
+    """Create a test for a deprecated POST definition (interpret) endpoint."""
+
+    def test_impl(_: object) -> None:
+        payload = {
+            "modelId": "test-model",
+            "protectedAttribute": "gender",
+            "outcomeName": "income",
+            "privilegedAttribute": "male",
+            "unprivilegedAttribute": "female",
+            "favorableOutcome": 1,
+            "metricValue": {"value": 0.85},
+        }
+        response = client.post(deprecated_path, json=payload)
+        assert response.status_code == HTTPStatus.NOT_IMPLEMENTED, (
+            f"Deprecated {metric_name} interpret should return 501"
+        )
+
+    return test_impl
+
+
+def make_deprecated_schedule_test(
+    metric_name: str,
+    module_path: str,
+    deprecated_path: str,
+    client: TestClient,
+    request_payload: dict[str, Any],
+) -> Callable[[], None]:
+    """Create a test for a deprecated schedule endpoint."""
+
+    @patch(f"{module_path}.get_prometheus_scheduler")
+    def test_impl(_: object, mock_sched_fn: MagicMock) -> None:
+        mock_sched = MagicMock()
+        mock_sched.register = AsyncMock(return_value=None)
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.post(deprecated_path, json=request_payload)
+
+        assert response.status_code == HTTPStatus.OK, (
+            f"Deprecated {metric_name} schedule failed: {response.text}"
+        )
+        data = response.json()
+        assert "requestId" in data
+
+    return test_impl
+
+
+def make_deprecated_delete_test(
+    metric_name: str,
+    module_path: str,
+    deprecated_path: str,
+    client: TestClient,
+) -> Callable[[], None]:
+    """Create a test for a deprecated delete-schedule endpoint."""
+
+    @patch(f"{module_path}.get_prometheus_scheduler")
+    def test_impl(_: object, mock_sched_fn: MagicMock) -> None:
+        mock_sched = MagicMock()
+        mock_sched.delete = AsyncMock(return_value=None)
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.request(
+            "DELETE",
+            deprecated_path,
+            json={"requestId": "123e4567-e89b-12d3-a456-426614174000"},
+        )
+
+        assert response.status_code == HTTPStatus.OK, (
+            f"Deprecated {metric_name} delete failed: {response.text}"
+        )
+        data = response.json()
+        assert data["status"] == "success"
+
+    return test_impl
+
+
+def make_deprecated_list_test(
+    metric_name: str,
+    module_path: str,
+    deprecated_path: str,
+    client: TestClient,
+) -> Callable[[], None]:
+    """Create a test for a deprecated list-requests endpoint."""
+
+    @patch(f"{module_path}.get_prometheus_scheduler")
+    def test_impl(_: object, mock_sched_fn: MagicMock) -> None:
+        mock_sched = MagicMock()
+        mock_sched.get_requests = MagicMock(return_value={})
+        mock_sched_fn.return_value = mock_sched
+
+        response = client.get(deprecated_path)
+
+        assert response.status_code == HTTPStatus.OK, (
+            f"Deprecated {metric_name} list failed: {response.text}"
+        )
+        data = response.json()
+        assert "requests" in data
+        assert isinstance(data["requests"], list)
+
+    return test_impl
+
+
+# ============================================================================
+# Compute with custom delta / thresholds
+# ============================================================================
+
+
+def make_compute_with_query_delta_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+    request_payload: dict[str, Any],
+    query_delta: float,
+    fairness_target: float,
+) -> Callable[[], None]:
+    """Create a test that passes delta as a query parameter."""
+
+    @patch(f"{module_path}.get_data_source")
+    def test_impl(_: object, mock_ds: MagicMock) -> None:
+        sample_df = _create_fairness_dataframe(
+            protected_attr=request_payload.get("protectedAttribute", "gender"),
+            outcome_name=request_payload.get("outcomeName", "income"),
+        )
+        mock_data_source = MagicMock()
+        mock_data_source.get_organic_dataframe = AsyncMock(return_value=sample_df)
+        mock_ds.return_value = mock_data_source
+
+        response = client.post(
+            f"{endpoint_path}?delta={query_delta}",
+            json=request_payload,
+        )
+
+        assert response.status_code == HTTPStatus.OK, (
+            f"{metric_name} compute with query delta failed: {response.text}"
+        )
+        data = response.json()
+        thresholds = data["thresholds"]
+        assert thresholds["lowerBound"] == fairness_target - query_delta
+        assert thresholds["upperBound"] == fairness_target + query_delta
+
+    return test_impl
+
+
+def make_compute_with_threshold_delta_in_body_test(
+    metric_name: str,
+    module_path: str,
+    endpoint_path: str,
+    client: TestClient,
+    request_payload: dict[str, Any],
+    body_delta: float,
+    fairness_target: float,
+) -> Callable[[], None]:
+    """Create a test that passes thresholdDelta in the request body."""
+
+    @patch(f"{module_path}.get_data_source")
+    def test_impl(_: object, mock_ds: MagicMock) -> None:
+        sample_df = _create_fairness_dataframe(
+            protected_attr=request_payload.get("protectedAttribute", "gender"),
+            outcome_name=request_payload.get("outcomeName", "income"),
+        )
+        mock_data_source = MagicMock()
+        mock_data_source.get_organic_dataframe = AsyncMock(return_value=sample_df)
+        mock_ds.return_value = mock_data_source
+
+        payload_with_delta = {**request_payload, "thresholdDelta": body_delta}
+        response = client.post(endpoint_path, json=payload_with_delta)
+
+        assert response.status_code == HTTPStatus.OK, (
+            f"{metric_name} compute with body delta failed: {response.text}"
+        )
+        data = response.json()
+        thresholds = data["thresholds"]
+        assert thresholds["lowerBound"] == fairness_target - body_delta
+        assert thresholds["upperBound"] == fairness_target + body_delta
+
+    return test_impl
+
+
+# ============================================================================
+# GroupMetricRequest.retrieve_tags() test
+# ============================================================================
+
+
+def make_retrieve_tags_test() -> Callable[[Any], None]:
+    """Create a test for GroupMetricRequest.retrieve_tags()."""
+
+    def test_impl(_: object) -> None:
+        from trustyai_service.endpoints.metrics.fairness.group.utils import (
+            GroupMetricRequest,
+        )
+
+        request = GroupMetricRequest.model_validate(
+            {
+                "modelId": "test-model",
+                "protectedAttribute": "gender",
+                "outcomeName": "income",
+                "privilegedAttribute": "male",
+                "unprivilegedAttribute": "female",
+                "favorableOutcome": 1,
+            }
+        )
+        tags = request.retrieve_tags()
+        assert tags["modelId"] == "test-model"
+        assert tags["protectedAttribute"] == "gender"
+        assert tags["outcomeName"] == "income"
+
+    return test_impl

--- a/tests/endpoints/metrics/fairness/group/test_dir.py
+++ b/tests/endpoints/metrics/fairness/group/test_dir.py
@@ -1,0 +1,359 @@
+"""Tests for Disparate Impact Ratio (DIR) fairness metric endpoint.
+
+Covers all six endpoint routes plus their deprecated aliases:
+
+- POST /metrics/group/fairness/dir            (compute)
+- GET  /metrics/group/fairness/dir/definition  (definition)
+- POST /metrics/group/fairness/dir/definition  (interpret - 501)
+- POST /metrics/group/fairness/dir/request     (schedule)
+- DELETE /metrics/group/fairness/dir/request   (delete schedule)
+- GET  /metrics/group/fairness/dir/requests    (list schedules)
+"""
+
+from http import HTTPStatus
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from trustyai_service.endpoints.metrics.fairness.group.dir import (
+    DEFAULT_DIR_THRESHOLD_DELTA,
+    DIR_FAIRNESS_TARGET,
+    router,
+)
+
+from . import factory
+
+# ---------------------------------------------------------------------------
+# Test app setup
+# ---------------------------------------------------------------------------
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+# Module path used for all patches
+_MODULE = "trustyai_service.endpoints.metrics.fairness.group.dir"
+
+# Standard request payload
+_PAYLOAD = factory._base_request_payload()
+
+# Response keys expected from the compute endpoint
+_COMPUTE_KEYS = ["name", "value", "type", "specificDefinition", "thresholds"]
+
+
+class TestDIREndpoints:
+    """Endpoint tests for Disparate Impact Ratio (DIR) metric."""
+
+    # ====================================================================
+    # Success cases
+    # ====================================================================
+
+    test_compute_endpoint = factory.make_compute_endpoint_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/dir",
+        client=client,
+        request_payload=_PAYLOAD,
+        expected_response_keys=_COMPUTE_KEYS,
+    )
+
+    test_definition_endpoint = factory.make_definition_endpoint_test(
+        metric_name="DIR",
+        endpoint_path="/metrics/group/fairness/dir/definition",
+        client=client,
+        expected_name="Disparate Impact Ratio",
+    )
+
+    test_interpret_value_not_implemented = (
+        factory.make_interpret_value_not_implemented_test(
+            metric_name="DIR",
+            endpoint_path="/metrics/group/fairness/dir/definition",
+            client=client,
+        )
+    )
+
+    test_schedule_endpoint = factory.make_schedule_endpoint_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/dir/request",
+        client=client,
+        request_payload=_PAYLOAD,
+    )
+
+    test_delete_schedule_endpoint = factory.make_delete_schedule_endpoint_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/dir/request",
+        client=client,
+    )
+
+    test_list_requests_endpoint = factory.make_list_requests_endpoint_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/dir/requests",
+        client=client,
+    )
+
+    # ====================================================================
+    # Threshold / delta tests
+    # ====================================================================
+
+    test_compute_with_query_delta = factory.make_compute_with_query_delta_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/dir",
+        client=client,
+        request_payload=_PAYLOAD,
+        query_delta=0.3,
+        fairness_target=DIR_FAIRNESS_TARGET,
+    )
+
+    test_compute_with_body_delta = (
+        factory.make_compute_with_threshold_delta_in_body_test(
+            metric_name="DIR",
+            module_path=_MODULE,
+            endpoint_path="/metrics/group/fairness/dir",
+            client=client,
+            request_payload=_PAYLOAD,
+            body_delta=0.15,
+            fairness_target=DIR_FAIRNESS_TARGET,
+        )
+    )
+
+    def test_compute_uses_default_delta(self) -> None:
+        """Verify the default threshold delta is applied when none is provided."""
+        with patch(f"{_MODULE}.get_data_source") as mock_ds:
+            sample_df = factory._create_fairness_dataframe()
+            mock_data_source = MagicMock()
+            mock_data_source.get_organic_dataframe = AsyncMock(return_value=sample_df)
+            mock_ds.return_value = mock_data_source
+
+            response = client.post("/metrics/group/fairness/dir", json=_PAYLOAD)
+
+            assert response.status_code == HTTPStatus.OK
+            thresholds = response.json()["thresholds"]
+            assert thresholds["lowerBound"] == (
+                DIR_FAIRNESS_TARGET - DEFAULT_DIR_THRESHOLD_DELTA
+            )
+            assert thresholds["upperBound"] == (
+                DIR_FAIRNESS_TARGET + DEFAULT_DIR_THRESHOLD_DELTA
+            )
+
+    # ====================================================================
+    # Edge cases
+    # ====================================================================
+
+    test_list_with_data = factory.make_list_requests_with_data_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/dir/requests",
+        client=client,
+        num_requests=3,
+    )
+
+    test_list_filters_malformed = factory.make_list_requests_with_malformed_data_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/dir/requests",
+        client=client,
+        num_valid_requests=2,
+        num_malformed_requests=2,
+    )
+
+    def test_compute_returns_correct_metric_name(self) -> None:
+        """Verify the response has name='DIR'."""
+        with patch(f"{_MODULE}.get_data_source") as mock_ds:
+            sample_df = factory._create_fairness_dataframe()
+            mock_data_source = MagicMock()
+            mock_data_source.get_organic_dataframe = AsyncMock(return_value=sample_df)
+            mock_ds.return_value = mock_data_source
+
+            data = client.post("/metrics/group/fairness/dir", json=_PAYLOAD).json()
+            assert data["name"] == "DIR"
+            assert data["type"] == "metric"
+
+    def test_compute_dir_value_range(self) -> None:
+        """DIR should be >= 0 for valid data."""
+        with patch(f"{_MODULE}.get_data_source") as mock_ds:
+            sample_df = factory._create_fairness_dataframe()
+            mock_data_source = MagicMock()
+            mock_data_source.get_organic_dataframe = AsyncMock(return_value=sample_df)
+            mock_ds.return_value = mock_data_source
+
+            data = client.post("/metrics/group/fairness/dir", json=_PAYLOAD).json()
+            assert data["value"] >= 0
+
+    # ====================================================================
+    # Error handling
+    # ====================================================================
+
+    test_compute_empty_data = factory.make_compute_empty_data_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/dir",
+        client=client,
+        request_payload=_PAYLOAD,
+    )
+
+    test_compute_generic_exception = factory.make_compute_generic_exception_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/dir",
+        client=client,
+        request_payload=_PAYLOAD,
+    )
+
+    test_compute_missing_model_id = factory.make_compute_endpoint_validation_error_test(
+        metric_name="DIR",
+        endpoint_path="/metrics/group/fairness/dir",
+        client=client,
+        request_payload={
+            # missing modelId
+            "protectedAttribute": "gender",
+            "outcomeName": "income",
+            "privilegedAttribute": "male",
+            "unprivilegedAttribute": "female",
+            "favorableOutcome": 1,
+        },
+        expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+        expected_error_substring="modelId",
+    )
+
+    test_compute_missing_protected_attribute = (
+        factory.make_compute_endpoint_validation_error_test(
+            metric_name="DIR",
+            endpoint_path="/metrics/group/fairness/dir",
+            client=client,
+            request_payload={
+                "modelId": "test-model",
+                # missing protectedAttribute
+                "outcomeName": "income",
+                "privilegedAttribute": "male",
+                "unprivilegedAttribute": "female",
+                "favorableOutcome": 1,
+            },
+            expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            expected_error_substring="protectedAttribute",
+        )
+    )
+
+    test_compute_empty_body = factory.make_compute_endpoint_validation_error_test(
+        metric_name="DIR",
+        endpoint_path="/metrics/group/fairness/dir",
+        client=client,
+        request_payload={},
+        expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+        expected_error_substring="Field required",
+    )
+
+    test_delete_invalid_uuid = factory.make_delete_invalid_uuid_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/dir/request",
+        client=client,
+    )
+
+    # ====================================================================
+    # Scheduler error tests
+    # ====================================================================
+
+    test_schedule_scheduler_unavailable = (
+        factory.make_schedule_scheduler_unavailable_test(
+            metric_name="DIR",
+            module_path=_MODULE,
+            endpoint_path="/metrics/group/fairness/dir/request",
+            client=client,
+            request_payload=_PAYLOAD,
+        )
+    )
+
+    test_schedule_register_exception = factory.make_schedule_register_exception_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/dir/request",
+        client=client,
+        request_payload=_PAYLOAD,
+    )
+
+    test_delete_scheduler_unavailable = factory.make_delete_scheduler_unavailable_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/dir/request",
+        client=client,
+    )
+
+    test_delete_exception = factory.make_delete_exception_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/dir/request",
+        client=client,
+    )
+
+    test_list_scheduler_unavailable = factory.make_list_scheduler_unavailable_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/dir/requests",
+        client=client,
+    )
+
+    test_list_exception = factory.make_list_exception_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/dir/requests",
+        client=client,
+    )
+
+    # ====================================================================
+    # Deprecated endpoint tests
+    # ====================================================================
+
+    test_deprecated_compute = factory.make_deprecated_compute_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        deprecated_path="/dir",
+        client=client,
+        request_payload=_PAYLOAD,
+        expected_response_keys=_COMPUTE_KEYS,
+    )
+
+    test_deprecated_definition = factory.make_deprecated_definition_test(
+        metric_name="DIR",
+        deprecated_path="/dir/definition",
+        client=client,
+        expected_name_substring="Disparate Impact Ratio",
+    )
+
+    test_deprecated_interpret = factory.make_deprecated_interpret_test(
+        metric_name="DIR",
+        deprecated_path="/dir/definition",
+        client=client,
+    )
+
+    test_deprecated_schedule = factory.make_deprecated_schedule_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        deprecated_path="/dir/request",
+        client=client,
+        request_payload=_PAYLOAD,
+    )
+
+    test_deprecated_delete = factory.make_deprecated_delete_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        deprecated_path="/dir/request",
+        client=client,
+    )
+
+    test_deprecated_list = factory.make_deprecated_list_test(
+        metric_name="DIR",
+        module_path=_MODULE,
+        deprecated_path="/dir/requests",
+        client=client,
+    )
+
+    # ====================================================================
+    # GroupMetricRequest model tests
+    # ====================================================================
+
+    test_retrieve_tags = factory.make_retrieve_tags_test()

--- a/tests/endpoints/metrics/fairness/group/test_spd.py
+++ b/tests/endpoints/metrics/fairness/group/test_spd.py
@@ -1,0 +1,359 @@
+"""Tests for Statistical Parity Difference (SPD) fairness metric endpoint.
+
+Covers all six endpoint routes plus their deprecated aliases:
+
+- POST /metrics/group/fairness/spd            (compute)
+- GET  /metrics/group/fairness/spd/definition  (definition)
+- POST /metrics/group/fairness/spd/definition  (interpret - 501)
+- POST /metrics/group/fairness/spd/request     (schedule)
+- DELETE /metrics/group/fairness/spd/request   (delete schedule)
+- GET  /metrics/group/fairness/spd/requests    (list schedules)
+"""
+
+from http import HTTPStatus
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from trustyai_service.endpoints.metrics.fairness.group.spd import (
+    DEFAULT_SPD_THRESHOLD_DELTA,
+    SPD_FAIRNESS_TARGET,
+    router,
+)
+
+from . import factory
+
+# ---------------------------------------------------------------------------
+# Test app setup
+# ---------------------------------------------------------------------------
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+# Module path used for all patches
+_MODULE = "trustyai_service.endpoints.metrics.fairness.group.spd"
+
+# Standard request payload
+_PAYLOAD = factory._base_request_payload()
+
+# Response keys expected from the compute endpoint
+_COMPUTE_KEYS = ["name", "value", "type", "specificDefinition", "thresholds"]
+
+
+class TestSPDEndpoints:
+    """Endpoint tests for Statistical Parity Difference (SPD) metric."""
+
+    # ====================================================================
+    # Success cases
+    # ====================================================================
+
+    test_compute_endpoint = factory.make_compute_endpoint_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/spd",
+        client=client,
+        request_payload=_PAYLOAD,
+        expected_response_keys=_COMPUTE_KEYS,
+    )
+
+    test_definition_endpoint = factory.make_definition_endpoint_test(
+        metric_name="SPD",
+        endpoint_path="/metrics/group/fairness/spd/definition",
+        client=client,
+        expected_name="Statistical Parity Difference",
+    )
+
+    test_interpret_value_not_implemented = (
+        factory.make_interpret_value_not_implemented_test(
+            metric_name="SPD",
+            endpoint_path="/metrics/group/fairness/spd/definition",
+            client=client,
+        )
+    )
+
+    test_schedule_endpoint = factory.make_schedule_endpoint_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/spd/request",
+        client=client,
+        request_payload=_PAYLOAD,
+    )
+
+    test_delete_schedule_endpoint = factory.make_delete_schedule_endpoint_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/spd/request",
+        client=client,
+    )
+
+    test_list_requests_endpoint = factory.make_list_requests_endpoint_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/spd/requests",
+        client=client,
+    )
+
+    # ====================================================================
+    # Threshold / delta tests
+    # ====================================================================
+
+    test_compute_with_query_delta = factory.make_compute_with_query_delta_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/spd",
+        client=client,
+        request_payload=_PAYLOAD,
+        query_delta=0.2,
+        fairness_target=SPD_FAIRNESS_TARGET,
+    )
+
+    test_compute_with_body_delta = (
+        factory.make_compute_with_threshold_delta_in_body_test(
+            metric_name="SPD",
+            module_path=_MODULE,
+            endpoint_path="/metrics/group/fairness/spd",
+            client=client,
+            request_payload=_PAYLOAD,
+            body_delta=0.05,
+            fairness_target=SPD_FAIRNESS_TARGET,
+        )
+    )
+
+    def test_compute_uses_default_delta(self) -> None:
+        """Verify the default threshold delta is applied when none is provided."""
+        with patch(f"{_MODULE}.get_data_source") as mock_ds:
+            sample_df = factory._create_fairness_dataframe()
+            mock_data_source = MagicMock()
+            mock_data_source.get_organic_dataframe = AsyncMock(return_value=sample_df)
+            mock_ds.return_value = mock_data_source
+
+            response = client.post("/metrics/group/fairness/spd", json=_PAYLOAD)
+
+            assert response.status_code == HTTPStatus.OK
+            thresholds = response.json()["thresholds"]
+            assert thresholds["lowerBound"] == (
+                SPD_FAIRNESS_TARGET - DEFAULT_SPD_THRESHOLD_DELTA
+            )
+            assert thresholds["upperBound"] == (
+                SPD_FAIRNESS_TARGET + DEFAULT_SPD_THRESHOLD_DELTA
+            )
+
+    # ====================================================================
+    # Edge cases
+    # ====================================================================
+
+    test_list_with_data = factory.make_list_requests_with_data_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/spd/requests",
+        client=client,
+        num_requests=3,
+    )
+
+    test_list_filters_malformed = factory.make_list_requests_with_malformed_data_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/spd/requests",
+        client=client,
+        num_valid_requests=2,
+        num_malformed_requests=2,
+    )
+
+    def test_compute_returns_correct_metric_name(self) -> None:
+        """Verify the response has name='SPD'."""
+        with patch(f"{_MODULE}.get_data_source") as mock_ds:
+            sample_df = factory._create_fairness_dataframe()
+            mock_data_source = MagicMock()
+            mock_data_source.get_organic_dataframe = AsyncMock(return_value=sample_df)
+            mock_ds.return_value = mock_data_source
+
+            data = client.post("/metrics/group/fairness/spd", json=_PAYLOAD).json()
+            assert data["name"] == "SPD"
+            assert data["type"] == "metric"
+
+    def test_compute_spd_value_range(self) -> None:
+        """SPD should be in [-1, 1] for valid data."""
+        with patch(f"{_MODULE}.get_data_source") as mock_ds:
+            sample_df = factory._create_fairness_dataframe()
+            mock_data_source = MagicMock()
+            mock_data_source.get_organic_dataframe = AsyncMock(return_value=sample_df)
+            mock_ds.return_value = mock_data_source
+
+            data = client.post("/metrics/group/fairness/spd", json=_PAYLOAD).json()
+            assert -1 <= data["value"] <= 1
+
+    # ====================================================================
+    # Error handling
+    # ====================================================================
+
+    test_compute_empty_data = factory.make_compute_empty_data_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/spd",
+        client=client,
+        request_payload=_PAYLOAD,
+    )
+
+    test_compute_generic_exception = factory.make_compute_generic_exception_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/spd",
+        client=client,
+        request_payload=_PAYLOAD,
+    )
+
+    test_compute_missing_model_id = factory.make_compute_endpoint_validation_error_test(
+        metric_name="SPD",
+        endpoint_path="/metrics/group/fairness/spd",
+        client=client,
+        request_payload={
+            # missing modelId
+            "protectedAttribute": "gender",
+            "outcomeName": "income",
+            "privilegedAttribute": "male",
+            "unprivilegedAttribute": "female",
+            "favorableOutcome": 1,
+        },
+        expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+        expected_error_substring="modelId",
+    )
+
+    test_compute_missing_protected_attribute = (
+        factory.make_compute_endpoint_validation_error_test(
+            metric_name="SPD",
+            endpoint_path="/metrics/group/fairness/spd",
+            client=client,
+            request_payload={
+                "modelId": "test-model",
+                # missing protectedAttribute
+                "outcomeName": "income",
+                "privilegedAttribute": "male",
+                "unprivilegedAttribute": "female",
+                "favorableOutcome": 1,
+            },
+            expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            expected_error_substring="protectedAttribute",
+        )
+    )
+
+    test_compute_empty_body = factory.make_compute_endpoint_validation_error_test(
+        metric_name="SPD",
+        endpoint_path="/metrics/group/fairness/spd",
+        client=client,
+        request_payload={},
+        expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+        expected_error_substring="Field required",
+    )
+
+    test_delete_invalid_uuid = factory.make_delete_invalid_uuid_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/spd/request",
+        client=client,
+    )
+
+    # ====================================================================
+    # Scheduler error tests
+    # ====================================================================
+
+    test_schedule_scheduler_unavailable = (
+        factory.make_schedule_scheduler_unavailable_test(
+            metric_name="SPD",
+            module_path=_MODULE,
+            endpoint_path="/metrics/group/fairness/spd/request",
+            client=client,
+            request_payload=_PAYLOAD,
+        )
+    )
+
+    test_schedule_register_exception = factory.make_schedule_register_exception_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/spd/request",
+        client=client,
+        request_payload=_PAYLOAD,
+    )
+
+    test_delete_scheduler_unavailable = factory.make_delete_scheduler_unavailable_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/spd/request",
+        client=client,
+    )
+
+    test_delete_exception = factory.make_delete_exception_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/spd/request",
+        client=client,
+    )
+
+    test_list_scheduler_unavailable = factory.make_list_scheduler_unavailable_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/spd/requests",
+        client=client,
+    )
+
+    test_list_exception = factory.make_list_exception_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        endpoint_path="/metrics/group/fairness/spd/requests",
+        client=client,
+    )
+
+    # ====================================================================
+    # Deprecated endpoint tests
+    # ====================================================================
+
+    test_deprecated_compute = factory.make_deprecated_compute_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        deprecated_path="/spd",
+        client=client,
+        request_payload=_PAYLOAD,
+        expected_response_keys=_COMPUTE_KEYS,
+    )
+
+    test_deprecated_definition = factory.make_deprecated_definition_test(
+        metric_name="SPD",
+        deprecated_path="/spd/definition",
+        client=client,
+        expected_name_substring="Statistical Parity Difference",
+    )
+
+    test_deprecated_interpret = factory.make_deprecated_interpret_test(
+        metric_name="SPD",
+        deprecated_path="/spd/definition",
+        client=client,
+    )
+
+    test_deprecated_schedule = factory.make_deprecated_schedule_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        deprecated_path="/spd/request",
+        client=client,
+        request_payload=_PAYLOAD,
+    )
+
+    test_deprecated_delete = factory.make_deprecated_delete_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        deprecated_path="/spd/request",
+        client=client,
+    )
+
+    test_deprecated_list = factory.make_deprecated_list_test(
+        metric_name="SPD",
+        module_path=_MODULE,
+        deprecated_path="/spd/requests",
+        client=client,
+    )
+
+    # ====================================================================
+    # GroupMetricRequest model tests
+    # ====================================================================
+
+    test_retrieve_tags = factory.make_retrieve_tags_test()


### PR DESCRIPTION
## Summary
- 64 tests (32 DIR + 32 SPD) using a shared factory pattern
- Covers all 6 routes per metric, deprecated aliases, error cases, scheduler interactions, and threshold delta handling
- Fixes latent bug: `request.modelId` → `request.model_id` in dir.py and spd.py schedule endpoints (Pydantic alias vs field name)
- Raises fairness group coverage from 40.9% to >80%

## Test plan
- [x] All 64 tests pass locally
- [x] CI passes

Ref: RHOAIENG-71280

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected fairness metric endpoint logging to consistently record the model identifier.

- **Tests**
  - Added comprehensive coverage for DIR and SPD group fairness endpoints, including deprecated routes.
  - Added tests for threshold handling, scheduling workflows, validation, error responses, malformed data, and metric value ranges.
  - Added coverage for tag retrieval and default threshold behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->