### PR TITLE
test(storage): improve PVC and MariaDB storage backend test coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trustyai-service"
-dynamic = ["version"]
+version = "1.0.0rc0"
 description = "TrustyAI Service"
 authors = [{ name = "Rui Vieira" }, { name = "TrustyAI team" }]
 requires-python = ">=3.12, <3.15"
@@ -11,7 +11,7 @@ dependencies = [
     "numpy>=2.0,<3",
     "pandas>=3.0,<4",
     "polars>=1.2,<2",
-    "fastapi>=0.116,<0.140",
+    "fastapi>=0.116,<0.138",
     "fastapi-utils>=0.8,<0.9",
     "uvicorn>=0.38,<1",
     "typing-inspect>=0.9,<1",
@@ -45,7 +45,7 @@ test = [
     "pytest-xdist[psutil]>=3.8.0",
     "hypothesis>=6.151.12",
     "aif360>=0.6.1",
-    "pillow>=12.3.0",        # Security: Resolves CVE-2026-25990 (HIGH - Out-of-bounds write)
+    "pillow>=12.2.0",        # Security: Resolves CVE-2026-25990 (HIGH - Out-of-bounds write)
 ]
 notebook = [
     "ipykernel>=7.2.0",
@@ -56,36 +56,25 @@ notebook = [
 [project.optional-dependencies]
 eval = [
     "lm-eval[api]>=0.4,<0.5",
-    "nltk>=3.10.0,<4",        # Security: Resolves CVE-2025-14009 (CRITICAL - Zip Slip), CVE-2026-33236, CVE-2026-33231 (HIGH), and 2 MEDIUM
+    "nltk>=3.9.4,<4",        # Security: Resolves CVE-2025-14009 (CRITICAL - Zip Slip), CVE-2026-33236, CVE-2026-33231 (HIGH), and 2 MEDIUM
     "sqlitedict>=2.1,<3",    # Security: Resolves CVE-2024-35515 (HIGH)
 ]
 # Note: grpcio/grpcio-tools removed - incompatible with protobuf v7, unused (protoc used instead)
 mariadb = ["mariadb>=1.1,<1.2", "javaobj-py3>=0.5,<0.6"]
 
-[tool.hatch.version]
-source = "vcs"
-fallback-version = "0.0.0.dev0"
-
-[tool.hatch.version.raw-options]
-version_scheme = "no-guess-dev"
-local_scheme = "dirty-tag"
-
 [tool.hatch.build.targets.sdist]
-packages = ["src/trustyai_service"]
+include = ["src"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/trustyai_service"]
-
-[tool.hatch.build.hooks.vcs]
-version-file = "src/trustyai_service/_version.py"
+include = ["src"]
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.ruff]
 # Exclude generated protobuf files from all ruff operations
-exclude = ["src/trustyai_service/proto/grpc_predict_v2_pb2.py", "src/trustyai_service/_version.py"]
+exclude = ["src/proto/grpc_predict_v2_pb2.py"]
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -98,27 +87,28 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 # === SRC FILES ===
-"src/trustyai_service/core/metrics/drift/jensen_shannon.py" = ["PLR0913"]
-"src/trustyai_service/core/metrics/fairness/group/*.py" = ["PLR0913"]
-"src/trustyai_service/middleware/gzip_middleware.py" = ["C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915"]
-"src/trustyai_service/service/data/datasources/data_source.py" = ["BLE001", "C901", "PLR0912"]
-"src/trustyai_service/service/data/modelmesh_parser.py" = ["PLR0913"]
-"src/trustyai_service/service/data/storage/**/*.py" = ["SLF001", "BLE001", "PLR0913"]
-"src/trustyai_service/service/data/storage/pvc.py" = ["C901", "PLR0912", "PLR0915", "ASYNC240", "PTH110"]
-"src/trustyai_service/service/payloads/**/*.py" = ["SLF001"]
-"src/trustyai_service/service/payloads/metrics/request_reconciler.py" = ["C901", "PLR0912", "PLR0915"]
-"src/trustyai_service/service/prometheus/prometheus_publisher.py" = ["SLF001"]
-"src/trustyai_service/service/prometheus/prometheus_scheduler.py" = ["BLE001"]
-"src/trustyai_service/endpoints/consumer/*.py" = ["N815"]
-"src/trustyai_service/endpoints/consumer/__init__.py" = ["C901"]
-"src/trustyai_service/endpoints/consumer/consumer_endpoint.py" = ["BLE001", "C901", "PLR0912", "PLR0913", "PLR0915"]
-"src/trustyai_service/endpoints/evaluation/lm_evaluation_harness.py" = ["SLF001"]
-"src/trustyai_service/endpoints/explainers/*.py" = ["N815"]
-"src/trustyai_service/endpoints/metadata.py" = ["N815", "BLE001", "C901"]
-"src/trustyai_service/endpoints/metrics/**/*.py" = ["N815"]
-"src/trustyai_service/endpoints/metrics/fairness/group/*.py" = ["BLE001", "TRY300", "TRY301"]
-"src/trustyai_service/endpoints/metrics/drift/jensen_shannon.py" = ["TRY300", "TRY301"]
-"src/trustyai_service/endpoints/metrics/drift/compare_means.py" = ["C901", "TRY301"]
+"src/core/metrics/drift/jensen_shannon.py" = ["PLR0913"]
+"src/core/metrics/fairness/group/*.py" = ["PLR0913"]
+"src/middleware/gzip_middleware.py" = ["C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915"]
+"src/service/data/datasources/data_source.py" = ["BLE001", "C901", "PLR0912"]
+"src/service/data/modelmesh_parser.py" = ["PLR0913"]
+"src/service/data/storage/**/*.py" = ["SLF001", "BLE001", "PLR0913"]
+"src/service/data/storage/pvc.py" = ["C901", "PLR0912", "PLR0915", "ASYNC240", "PTH110"]
+"src/service/payloads/**/*.py" = ["SLF001"]
+"src/service/payloads/metrics/request_reconciler.py" = ["C901", "PLR0912", "PLR0915"]
+"src/service/prometheus/prometheus_publisher.py" = ["SLF001"]
+"src/service/prometheus/prometheus_scheduler.py" = ["BLE001"]
+"src/endpoints/consumer/*.py" = ["N815"]
+"src/endpoints/consumer/__init__.py" = ["C901"]
+"src/endpoints/consumer/consumer_endpoint.py" = ["BLE001", "C901", "PLR0912", "PLR0913", "PLR0915"]
+"src/endpoints/evaluation/lm_evaluation_harness.py" = ["SLF001"]
+"src/endpoints/explainers/*.py" = ["N815"]
+"src/endpoints/metadata.py" = ["N815", "BLE001", "C901"]
+"src/endpoints/metrics/**/*.py" = ["N815"]
+"src/endpoints/metrics/fairness/group/*.py" = ["BLE001", "TRY300", "TRY301"]
+"src/endpoints/metrics/drift/jensen_shannon.py" = ["TRY300", "TRY301"]
+"src/endpoints/metrics/drift/compare_means.py" = ["C901", "TRY301"]
+"src/service/config/registry.py" = ["PLR0913"]
 # === TEST FILES ===
 "tests/**" = ["S101", "PT019", "SLF001"]
 "tests/core/metrics/test_fairness.py" = ["N803", "N806"]
@@ -136,14 +126,13 @@ addopts = "--dist=loadgroup -n 4"
 [tool.bandit]
 exclude_dirs = ["tests/"]
 skips = [
-    "B104",  # hardcoded_bind_all_interfaces - intentional for service binding (src/trustyai_service/main.py)
-    "B108",  # hardcoded_tmp_directory - system temp dir usage (src/trustyai_service/service/data/storage/__init__.py)
+    "B104",  # hardcoded_bind_all_interfaces - intentional for service binding (src/main.py)
+    "B108",  # hardcoded_tmp_directory - system temp dir usage (src/service/data/storage/__init__.py)
     "B608",  # hardcoded_sql_expressions - false positives from table name construction in MariaDB storage (uses parameterized queries for actual data)
 ]
 
 [tool.pyrefly]
-search-path = ["."]
-project-excludes = ["**/proto/**", "src/trustyai_service/proto/**", "src/trustyai_service/proto/grpc_predict_v2_pb2.py", "src/trustyai_service/_version.py"]
+project-excludes = ["**/proto/**", "src/proto/**", "src/proto/grpc_predict_v2_pb2.py"]
 disable-project-excludes-heuristics = true
 # Forward-looking: pyrefly uses this for type checking, not runtime
 python-version = "3.14.0"
@@ -170,7 +159,7 @@ ignore-missing-imports = [
 # Broad suppressions for pre-existing type issues.
 # Will be tightened as code PRs fix root causes.
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/**/*.py"
+matches = "src/**/*.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
@@ -207,7 +196,7 @@ unsupported-operation = "ignore"
 
 # Suppress sklearn mixin false positives in fairness metrics
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/core/metrics/fairness/**"
+matches = "src/core/metrics/fairness/**"
 
 [tool.pyrefly.sub-config.errors]
 missing-attribute = "ignore"
@@ -229,7 +218,7 @@ missing-attribute = "ignore"
 no-access = "ignore"
 
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/service/payloads/metrics/request_reconciler.py"  # Schema_item validated before use (false positive)
+matches = "src/service/payloads/metrics/request_reconciler.py"  # Schema_item validated before use (false positive)
 
 [tool.pyrefly.sub-config.errors]
 missing-attribute = "ignore"
@@ -243,7 +232,7 @@ bad-argument-type = "ignore"
 
 # Suppress Pydantic Field() default overrides in metric requests
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/endpoints/metrics/**/*.py"
+matches = "src/endpoints/metrics/**/*.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-override = "ignore"
@@ -253,7 +242,7 @@ missing-attribute = "ignore"
 
 # Suppress storage interface implementation signature differences
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/service/data/storage/**/*.py"
+matches = "src/service/data/storage/**/*.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-override = "ignore"
@@ -266,7 +255,7 @@ not-iterable = "ignore"
 
 # Suppress h5py/numpy type issues in PVC storage
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/service/data/storage/pvc.py"
+matches = "src/service/data/storage/pvc.py"
 
 [tool.pyrefly.sub-config.errors]
 unsupported-operation = "ignore"
@@ -279,7 +268,7 @@ bad-param-name-override = "ignore"
 
 # Suppress evaluation harness dynamic model issues
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/endpoints/evaluation/lm_evaluation_harness.py"
+matches = "src/endpoints/evaluation/lm_evaluation_harness.py"
 
 [tool.pyrefly.sub-config.errors]
 no-matching-overload = "ignore"
@@ -289,7 +278,7 @@ missing-attribute = "ignore"
 # Suppress consumer endpoint union type validation issues
 # Runtime validation narrows union types before calling functions
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/endpoints/consumer/consumer_endpoint.py"
+matches = "src/endpoints/consumer/consumer_endpoint.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
@@ -303,7 +292,7 @@ missing-attribute = "ignore"
 
 # Suppress subprocess and config dict issues in main
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/main.py"
+matches = "src/main.py"
 
 [tool.pyrefly.sub-config.errors]
 missing-attribute = "ignore"
@@ -311,35 +300,35 @@ unsupported-operation = "ignore"
 
 # Suppress metadata endpoint config issues
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/endpoints/metadata.py"
+matches = "src/endpoints/metadata.py"
 
 [tool.pyrefly.sub-config.errors]
 unsupported-operation = "ignore"
 
 # Suppress model data tuple return type issues
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/service/data/model_data.py"
+matches = "src/service/data/model_data.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-return = "ignore"
 
 # Suppress legacy maria reader pandas Index issues
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/service/data/storage/maria/legacy_maria_reader.py"
+matches = "src/service/data/storage/maria/legacy_maria_reader.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
 
 # Suppress storage init int conversion issues
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/service/data/storage/__init__.py"
+matches = "src/service/data/storage/__init__.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
 
 # Suppress typed value optional return types
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/service/payloads/values/typed_value.py"
+matches = "src/service/payloads/values/typed_value.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-return = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trustyai-service"
-version = "1.0.0rc0"
+dynamic = ["version"]
 description = "TrustyAI Service"
 authors = [{ name = "Rui Vieira" }, { name = "TrustyAI team" }]
 requires-python = ">=3.12, <3.15"
@@ -11,7 +11,7 @@ dependencies = [
     "numpy>=2.0,<3",
     "pandas>=3.0,<4",
     "polars>=1.2,<2",
-    "fastapi>=0.116,<0.138",
+    "fastapi>=0.116,<0.140",
     "fastapi-utils>=0.8,<0.9",
     "uvicorn>=0.38,<1",
     "typing-inspect>=0.9,<1",
@@ -45,7 +45,7 @@ test = [
     "pytest-xdist[psutil]>=3.8.0",
     "hypothesis>=6.151.12",
     "aif360>=0.6.1",
-    "pillow>=12.2.0",        # Security: Resolves CVE-2026-25990 (HIGH - Out-of-bounds write)
+    "pillow>=12.3.0",        # Security: Resolves CVE-2026-25990 (HIGH - Out-of-bounds write)
 ]
 notebook = [
     "ipykernel>=7.2.0",
@@ -56,25 +56,36 @@ notebook = [
 [project.optional-dependencies]
 eval = [
     "lm-eval[api]>=0.4,<0.5",
-    "nltk>=3.9.4,<4",        # Security: Resolves CVE-2025-14009 (CRITICAL - Zip Slip), CVE-2026-33236, CVE-2026-33231 (HIGH), and 2 MEDIUM
+    "nltk>=3.10.0,<4",        # Security: Resolves CVE-2025-14009 (CRITICAL - Zip Slip), CVE-2026-33236, CVE-2026-33231 (HIGH), and 2 MEDIUM
     "sqlitedict>=2.1,<3",    # Security: Resolves CVE-2024-35515 (HIGH)
 ]
 # Note: grpcio/grpcio-tools removed - incompatible with protobuf v7, unused (protoc used instead)
 mariadb = ["mariadb>=1.1,<1.2", "javaobj-py3>=0.5,<0.6"]
 
+[tool.hatch.version]
+source = "vcs"
+fallback-version = "0.0.0.dev0"
+
+[tool.hatch.version.raw-options]
+version_scheme = "no-guess-dev"
+local_scheme = "dirty-tag"
+
 [tool.hatch.build.targets.sdist]
-include = ["src"]
+packages = ["src/trustyai_service"]
 
 [tool.hatch.build.targets.wheel]
-include = ["src"]
+packages = ["src/trustyai_service"]
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/trustyai_service/_version.py"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.ruff]
 # Exclude generated protobuf files from all ruff operations
-exclude = ["src/proto/grpc_predict_v2_pb2.py"]
+exclude = ["src/trustyai_service/proto/grpc_predict_v2_pb2.py", "src/trustyai_service/_version.py"]
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -87,28 +98,28 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 # === SRC FILES ===
-"src/core/metrics/drift/jensen_shannon.py" = ["PLR0913"]
-"src/core/metrics/fairness/group/*.py" = ["PLR0913"]
-"src/middleware/gzip_middleware.py" = ["C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915"]
-"src/service/data/datasources/data_source.py" = ["BLE001", "C901", "PLR0912"]
-"src/service/data/modelmesh_parser.py" = ["PLR0913"]
-"src/service/data/storage/**/*.py" = ["SLF001", "BLE001", "PLR0913"]
-"src/service/data/storage/pvc.py" = ["C901", "PLR0912", "PLR0915", "ASYNC240", "PTH110"]
-"src/service/payloads/**/*.py" = ["SLF001"]
-"src/service/payloads/metrics/request_reconciler.py" = ["C901", "PLR0912", "PLR0915"]
-"src/service/prometheus/prometheus_publisher.py" = ["SLF001"]
-"src/service/prometheus/prometheus_scheduler.py" = ["BLE001"]
-"src/endpoints/consumer/*.py" = ["N815"]
-"src/endpoints/consumer/__init__.py" = ["C901"]
-"src/endpoints/consumer/consumer_endpoint.py" = ["BLE001", "C901", "PLR0912", "PLR0913", "PLR0915"]
-"src/endpoints/evaluation/lm_evaluation_harness.py" = ["SLF001"]
-"src/endpoints/explainers/*.py" = ["N815"]
-"src/endpoints/metadata.py" = ["N815", "BLE001", "C901"]
-"src/endpoints/metrics/**/*.py" = ["N815"]
-"src/endpoints/metrics/fairness/group/*.py" = ["BLE001", "TRY300", "TRY301"]
-"src/endpoints/metrics/drift/jensen_shannon.py" = ["TRY300", "TRY301"]
-"src/endpoints/metrics/drift/compare_means.py" = ["C901", "TRY301"]
-"src/service/config/registry.py" = ["PLR0913"]
+"src/trustyai_service/core/metrics/drift/jensen_shannon.py" = ["PLR0913"]
+"src/trustyai_service/core/metrics/fairness/group/*.py" = ["PLR0913"]
+"src/trustyai_service/middleware/gzip_middleware.py" = ["C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915"]
+"src/trustyai_service/service/data/datasources/data_source.py" = ["BLE001", "C901", "PLR0912"]
+"src/trustyai_service/service/data/modelmesh_parser.py" = ["PLR0913"]
+"src/trustyai_service/service/data/storage/**/*.py" = ["SLF001", "BLE001", "PLR0913"]
+"src/trustyai_service/service/data/storage/pvc.py" = ["C901", "PLR0912", "PLR0915", "ASYNC240", "PTH110"]
+"src/trustyai_service/service/payloads/**/*.py" = ["SLF001"]
+"src/trustyai_service/service/payloads/metrics/request_reconciler.py" = ["C901", "PLR0912", "PLR0915"]
+"src/trustyai_service/service/prometheus/prometheus_publisher.py" = ["SLF001"]
+"src/trustyai_service/service/prometheus/prometheus_scheduler.py" = ["BLE001"]
+"src/trustyai_service/endpoints/consumer/*.py" = ["N815"]
+"src/trustyai_service/endpoints/consumer/__init__.py" = ["C901"]
+"src/trustyai_service/endpoints/consumer/consumer_endpoint.py" = ["BLE001", "C901", "PLR0912", "PLR0913", "PLR0915"]
+"src/trustyai_service/endpoints/evaluation/lm_evaluation_harness.py" = ["SLF001"]
+"src/trustyai_service/endpoints/explainers/*.py" = ["N815"]
+"src/trustyai_service/endpoints/metadata.py" = ["N815", "BLE001", "C901"]
+"src/trustyai_service/endpoints/metrics/**/*.py" = ["N815"]
+"src/trustyai_service/endpoints/metrics/fairness/group/*.py" = ["BLE001", "TRY300", "TRY301"]
+"src/trustyai_service/endpoints/metrics/drift/jensen_shannon.py" = ["TRY300", "TRY301"]
+"src/trustyai_service/endpoints/metrics/drift/compare_means.py" = ["C901", "TRY301"]
+"src/trustyai_service/service/config/registry.py" = ["PLR0913"]
 # === TEST FILES ===
 "tests/**" = ["S101", "PT019", "SLF001"]
 "tests/core/metrics/test_fairness.py" = ["N803", "N806"]
@@ -126,13 +137,14 @@ addopts = "--dist=loadgroup -n 4"
 [tool.bandit]
 exclude_dirs = ["tests/"]
 skips = [
-    "B104",  # hardcoded_bind_all_interfaces - intentional for service binding (src/main.py)
-    "B108",  # hardcoded_tmp_directory - system temp dir usage (src/service/data/storage/__init__.py)
+    "B104",  # hardcoded_bind_all_interfaces - intentional for service binding (src/trustyai_service/main.py)
+    "B108",  # hardcoded_tmp_directory - system temp dir usage (src/trustyai_service/service/data/storage/__init__.py)
     "B608",  # hardcoded_sql_expressions - false positives from table name construction in MariaDB storage (uses parameterized queries for actual data)
 ]
 
 [tool.pyrefly]
-project-excludes = ["**/proto/**", "src/proto/**", "src/proto/grpc_predict_v2_pb2.py"]
+search-path = ["."]
+project-excludes = ["**/proto/**", "src/trustyai_service/proto/**", "src/trustyai_service/proto/grpc_predict_v2_pb2.py", "src/trustyai_service/_version.py"]
 disable-project-excludes-heuristics = true
 # Forward-looking: pyrefly uses this for type checking, not runtime
 python-version = "3.14.0"
@@ -159,7 +171,7 @@ ignore-missing-imports = [
 # Broad suppressions for pre-existing type issues.
 # Will be tightened as code PRs fix root causes.
 [[tool.pyrefly.sub-config]]
-matches = "src/**/*.py"
+matches = "src/trustyai_service/**/*.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
@@ -196,7 +208,7 @@ unsupported-operation = "ignore"
 
 # Suppress sklearn mixin false positives in fairness metrics
 [[tool.pyrefly.sub-config]]
-matches = "src/core/metrics/fairness/**"
+matches = "src/trustyai_service/core/metrics/fairness/**"
 
 [tool.pyrefly.sub-config.errors]
 missing-attribute = "ignore"
@@ -218,7 +230,7 @@ missing-attribute = "ignore"
 no-access = "ignore"
 
 [[tool.pyrefly.sub-config]]
-matches = "src/service/payloads/metrics/request_reconciler.py"  # Schema_item validated before use (false positive)
+matches = "src/trustyai_service/service/payloads/metrics/request_reconciler.py"  # Schema_item validated before use (false positive)
 
 [tool.pyrefly.sub-config.errors]
 missing-attribute = "ignore"
@@ -232,7 +244,7 @@ bad-argument-type = "ignore"
 
 # Suppress Pydantic Field() default overrides in metric requests
 [[tool.pyrefly.sub-config]]
-matches = "src/endpoints/metrics/**/*.py"
+matches = "src/trustyai_service/endpoints/metrics/**/*.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-override = "ignore"
@@ -242,7 +254,7 @@ missing-attribute = "ignore"
 
 # Suppress storage interface implementation signature differences
 [[tool.pyrefly.sub-config]]
-matches = "src/service/data/storage/**/*.py"
+matches = "src/trustyai_service/service/data/storage/**/*.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-override = "ignore"
@@ -255,7 +267,7 @@ not-iterable = "ignore"
 
 # Suppress h5py/numpy type issues in PVC storage
 [[tool.pyrefly.sub-config]]
-matches = "src/service/data/storage/pvc.py"
+matches = "src/trustyai_service/service/data/storage/pvc.py"
 
 [tool.pyrefly.sub-config.errors]
 unsupported-operation = "ignore"
@@ -268,7 +280,7 @@ bad-param-name-override = "ignore"
 
 # Suppress evaluation harness dynamic model issues
 [[tool.pyrefly.sub-config]]
-matches = "src/endpoints/evaluation/lm_evaluation_harness.py"
+matches = "src/trustyai_service/endpoints/evaluation/lm_evaluation_harness.py"
 
 [tool.pyrefly.sub-config.errors]
 no-matching-overload = "ignore"
@@ -278,7 +290,7 @@ missing-attribute = "ignore"
 # Suppress consumer endpoint union type validation issues
 # Runtime validation narrows union types before calling functions
 [[tool.pyrefly.sub-config]]
-matches = "src/endpoints/consumer/consumer_endpoint.py"
+matches = "src/trustyai_service/endpoints/consumer/consumer_endpoint.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
@@ -292,7 +304,7 @@ missing-attribute = "ignore"
 
 # Suppress subprocess and config dict issues in main
 [[tool.pyrefly.sub-config]]
-matches = "src/main.py"
+matches = "src/trustyai_service/main.py"
 
 [tool.pyrefly.sub-config.errors]
 missing-attribute = "ignore"
@@ -300,35 +312,35 @@ unsupported-operation = "ignore"
 
 # Suppress metadata endpoint config issues
 [[tool.pyrefly.sub-config]]
-matches = "src/endpoints/metadata.py"
+matches = "src/trustyai_service/endpoints/metadata.py"
 
 [tool.pyrefly.sub-config.errors]
 unsupported-operation = "ignore"
 
 # Suppress model data tuple return type issues
 [[tool.pyrefly.sub-config]]
-matches = "src/service/data/model_data.py"
+matches = "src/trustyai_service/service/data/model_data.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-return = "ignore"
 
 # Suppress legacy maria reader pandas Index issues
 [[tool.pyrefly.sub-config]]
-matches = "src/service/data/storage/maria/legacy_maria_reader.py"
+matches = "src/trustyai_service/service/data/storage/maria/legacy_maria_reader.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
 
 # Suppress storage init int conversion issues
 [[tool.pyrefly.sub-config]]
-matches = "src/service/data/storage/__init__.py"
+matches = "src/trustyai_service/service/data/storage/__init__.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
 
 # Suppress typed value optional return types
 [[tool.pyrefly.sub-config]]
-matches = "src/service/payloads/values/typed_value.py"
+matches = "src/trustyai_service/service/payloads/values/typed_value.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-return = "ignore"

--- a/src/trustyai_service/main.py
+++ b/src/trustyai_service/main.py
@@ -11,8 +11,6 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import FastAPI, Request, Response
 
-from trustyai_service import __version__
-
 if TYPE_CHECKING:
     from fastapi import APIRouter
 from fastapi.middleware.cors import CORSMiddleware
@@ -22,41 +20,26 @@ from hypercorn.config import Config
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 # Endpoint routers
-from trustyai_service.endpoints.consumer.consumer_endpoint import (
-    router as consumer_router,
-)
+from trustyai_service.endpoints.consumer.consumer_endpoint import router as consumer_router
 from trustyai_service.endpoints.data.data_upload import router as data_upload_router
-from trustyai_service.endpoints.explainers.global_explainer import (
-    router as explainers_global_router,
-)
-from trustyai_service.endpoints.explainers.local_explainer import (
-    router as explainers_local_router,
-)
+from trustyai_service.endpoints.explainers.global_explainer import router as explainers_global_router
+from trustyai_service.endpoints.explainers.local_explainer import router as explainers_local_router
 from trustyai_service.endpoints.metadata import router as metadata_router
 from trustyai_service.endpoints.metrics.batch_mean import router as batch_mean_router
-from trustyai_service.endpoints.metrics.drift.approx_ks_test import (
-    router as drift_approxkstest_router,
-)
 from trustyai_service.endpoints.metrics.drift.compare_means import (
     router as drift_comparemeans_router,
-)
-from trustyai_service.endpoints.metrics.drift.fourier_mmd import (
-    router as drift_fouriermmd_router,
 )
 from trustyai_service.endpoints.metrics.drift.jensen_shannon import (
     router as drift_jensenshannon_router,
 )
-from trustyai_service.endpoints.metrics.drift.kolmogorov_smirnov import (
-    router as drift_kstest_router,
-)
+from trustyai_service.endpoints.metrics.drift.kolmogorov_smirnov import router as drift_kstest_router
 from trustyai_service.endpoints.metrics.fairness.group.dir import router as dir_router
 from trustyai_service.endpoints.metrics.fairness.group.spd import router as spd_router
-from trustyai_service.endpoints.metrics.metrics_info import (
-    router as metrics_info_router,
-)
+from trustyai_service.endpoints.metrics.metrics_info import router as metrics_info_router
 
 # Middleware
 from trustyai_service.middleware.gzip_middleware import GzipRequestMiddleware
+from trustyai_service.service.config.registry import register_if_enabled_with_group
 from trustyai_service.service.prometheus.shared_prometheus_scheduler import (
     get_shared_prometheus_scheduler,
 )
@@ -67,8 +50,6 @@ try:
 
     lm_evaluation_harness_router = router
 except ImportError:
-    # LM evaluation harness requires optional 'eval' extra dependencies
-    # ImportError (not ModuleNotFoundError) because the module may exist but fail to import
     pass
 
 logging.basicConfig(
@@ -86,9 +67,7 @@ logging.getLogger("hypercorn.protocol").setLevel(logging.INFO)
 logging.getLogger("hypercorn.access").setLevel(logging.INFO)
 
 # Ensure scheduler debug logging
-scheduler_logger = logging.getLogger(
-    "trustyai_service.service.prometheus.prometheus_scheduler"
-)
+scheduler_logger = logging.getLogger("trustyai_service.service.prometheus.prometheus_scheduler")
 scheduler_logger.setLevel(logging.DEBUG)
 logger = logging.getLogger(__name__)
 
@@ -132,7 +111,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
 
 app = FastAPI(
     title="TrustyAI Service API",
-    version=__version__,
+    version="1.0.0rc0",
     description="TrustyAI Service API",
     lifespan=lifespan,
 )
@@ -166,41 +145,63 @@ app.include_router(
     consumer_router,
     tags=["{Internal Only} Inference Consumer", "{Internal Only} ModelMesh Consumer"],
 )
-app.include_router(dir_router, tags=["Fairness Metrics: Group: Disparate Impact Ratio"])
 app.include_router(data_upload_router, tags=["Data Upload"])
 
-#   Drift metrics
-app.include_router(
-    drift_comparemeans_router,
-    tags=[
-        "Drift Metrics: CompareMeans",
-    ],
+# Fairness metrics (gated by "fairness" group + individual flags)
+register_if_enabled_with_group(
+    app,
+    dir_router,
+    "fairness",
+    "fairness_dir",
+    "Fairness Metrics: Group: Disparate Impact Ratio",
 )
-app.include_router(
-    drift_kstest_router,
-    tags=[
-        "Drift Metrics: KSTest",
-    ],
-)
-app.include_router(
-    drift_fouriermmd_router,
-    tags=["Drift Metrics: FourierMMD"],
-)
-app.include_router(
-    drift_approxkstest_router,
-    tags=["Drift Metrics: ApproxKSTest"],
-)
-app.include_router(
-    drift_jensenshannon_router,
-    tags=["Drift Metrics: JensenShannon"],
+register_if_enabled_with_group(
+    app,
+    spd_router,
+    "fairness",
+    "fairness_spd",
+    "Fairness Metrics: Group: Statistical Parity Difference",
 )
 
-app.include_router(explainers_global_router, tags=["Explainers: Global"])
-app.include_router(explainers_local_router, tags=["Explainers: Local"])
-app.include_router(
-    spd_router,
-    tags=["Fairness Metrics: Group: Statistical Parity Difference"],
+# Drift metrics (gated by "drift" group + individual flags)
+register_if_enabled_with_group(
+    app,
+    drift_comparemeans_router,
+    "drift",
+    "drift_compare_means",
+    "Drift Metrics: CompareMeans",
 )
+register_if_enabled_with_group(
+    app,
+    drift_kstest_router,
+    "drift",
+    "drift_ks_test",
+    "Drift Metrics: KSTest",
+)
+register_if_enabled_with_group(
+    app,
+    drift_jensenshannon_router,
+    "drift",
+    "drift_jensen_shannon",
+    "Drift Metrics: JensenShannon",
+)
+
+# Explainer endpoints (gated by "explainer" group + individual flags)
+register_if_enabled_with_group(
+    app,
+    explainers_local_router,
+    "explainer",
+    "explainer_local",
+    "Explainers: Local",
+)
+register_if_enabled_with_group(
+    app,
+    explainers_global_router,
+    "explainer",
+    "explainer_global",
+    "Explainers: Global",
+)
+
 app.include_router(batch_mean_router, tags=["Metrics: Batch Mean"])
 app.include_router(metadata_router, tags=["Service Metadata"])
 app.include_router(metrics_info_router, tags=["Metrics Information Endpoint"])
@@ -210,14 +211,22 @@ if lm_evaluation_harness_router is not None:
         lm_evaluation_harness_router, tags=["LM Evaluation Harness Endpoint"]
     )
 
-# Deprecated endpoints
-app.include_router(
-    dir_router, prefix="/metrics", tags=["{Legacy}: Disparate Impact Ratio"]
-)
-app.include_router(
-    spd_router,
+# Deprecated endpoints (gated by fairness group + individual flags)
+register_if_enabled_with_group(
+    app,
+    dir_router,
+    "fairness",
+    "fairness_dir",
     prefix="/metrics",
-    tags=["{Legacy}: Statistical Parity Difference"],
+    tag="{Legacy}: Disparate Impact Ratio",
+)
+register_if_enabled_with_group(
+    app,
+    spd_router,
+    "fairness",
+    "fairness_spd",
+    prefix="/metrics",
+    tag="{Legacy}: Statistical Parity Difference",
 )
 
 

--- a/src/trustyai_service/main.py
+++ b/src/trustyai_service/main.py
@@ -20,10 +20,16 @@ from hypercorn.config import Config
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 # Endpoint routers
-from trustyai_service.endpoints.consumer.consumer_endpoint import router as consumer_router
+from trustyai_service.endpoints.consumer.consumer_endpoint import (
+    router as consumer_router,
+)
 from trustyai_service.endpoints.data.data_upload import router as data_upload_router
-from trustyai_service.endpoints.explainers.global_explainer import router as explainers_global_router
-from trustyai_service.endpoints.explainers.local_explainer import router as explainers_local_router
+from trustyai_service.endpoints.explainers.global_explainer import (
+    router as explainers_global_router,
+)
+from trustyai_service.endpoints.explainers.local_explainer import (
+    router as explainers_local_router,
+)
 from trustyai_service.endpoints.metadata import router as metadata_router
 from trustyai_service.endpoints.metrics.batch_mean import router as batch_mean_router
 from trustyai_service.endpoints.metrics.drift.compare_means import (
@@ -32,10 +38,14 @@ from trustyai_service.endpoints.metrics.drift.compare_means import (
 from trustyai_service.endpoints.metrics.drift.jensen_shannon import (
     router as drift_jensenshannon_router,
 )
-from trustyai_service.endpoints.metrics.drift.kolmogorov_smirnov import router as drift_kstest_router
+from trustyai_service.endpoints.metrics.drift.kolmogorov_smirnov import (
+    router as drift_kstest_router,
+)
 from trustyai_service.endpoints.metrics.fairness.group.dir import router as dir_router
 from trustyai_service.endpoints.metrics.fairness.group.spd import router as spd_router
-from trustyai_service.endpoints.metrics.metrics_info import router as metrics_info_router
+from trustyai_service.endpoints.metrics.metrics_info import (
+    router as metrics_info_router,
+)
 
 # Middleware
 from trustyai_service.middleware.gzip_middleware import GzipRequestMiddleware
@@ -67,7 +77,9 @@ logging.getLogger("hypercorn.protocol").setLevel(logging.INFO)
 logging.getLogger("hypercorn.access").setLevel(logging.INFO)
 
 # Ensure scheduler debug logging
-scheduler_logger = logging.getLogger("trustyai_service.service.prometheus.prometheus_scheduler")
+scheduler_logger = logging.getLogger(
+    "trustyai_service.service.prometheus.prometheus_scheduler"
+)
 scheduler_logger.setLevel(logging.DEBUG)
 logger = logging.getLogger(__name__)
 

--- a/src/trustyai_service/service/config/__init__.py
+++ b/src/trustyai_service/service/config/__init__.py
@@ -1,0 +1,1 @@
+"""Feature flag configuration for endpoint gating."""

--- a/src/trustyai_service/service/config/feature_flags.py
+++ b/src/trustyai_service/service/config/feature_flags.py
@@ -15,8 +15,7 @@ _TRUTHY = frozenset({"1", "true", "yes", "on", "enabled"})
 _FALSY = frozenset({"0", "false", "no", "off", "disabled"})
 
 
-def _flag(name: str, default: bool) -> bool:
-    """Read a feature flag, allowing env-var override."""
+def _flag(name: str, *, default: bool) -> bool:
     env = os.getenv(f"TRUSTYAI_ENABLE_{name.upper()}")
     if env is not None:
         normalized = env.strip().lower()
@@ -34,15 +33,15 @@ def _flag(name: str, default: bool) -> bool:
 
 
 ENDPOINTS: dict[str, bool] = {
-    "fairness": _flag("fairness", True),
-    "fairness_spd": _flag("fairness_spd", True),
-    "fairness_dir": _flag("fairness_dir", True),
-    "drift": _flag("drift", True),
-    "drift_ks_test": _flag("drift_ks_test", True),
-    "drift_jensen_shannon": _flag("drift_jensen_shannon", True),
-    "drift_compare_means": _flag("drift_compare_means", True),
-    "data_download": _flag("data_download", False),
-    "explainer": _flag("explainer", False),
-    "explainer_local": _flag("explainer_local", False),
-    "explainer_global": _flag("explainer_global", False),
+    "fairness": _flag("fairness", default=True),
+    "fairness_spd": _flag("fairness_spd", default=True),
+    "fairness_dir": _flag("fairness_dir", default=True),
+    "drift": _flag("drift", default=True),
+    "drift_ks_test": _flag("drift_ks_test", default=True),
+    "drift_jensen_shannon": _flag("drift_jensen_shannon", default=True),
+    "drift_compare_means": _flag("drift_compare_means", default=True),
+    "data_download": _flag("data_download", default=False),
+    "explainer": _flag("explainer", default=False),
+    "explainer_local": _flag("explainer_local", default=False),
+    "explainer_global": _flag("explainer_global", default=False),
 }

--- a/src/trustyai_service/service/config/feature_flags.py
+++ b/src/trustyai_service/service/config/feature_flags.py
@@ -1,0 +1,48 @@
+"""Feature flags controlling endpoint availability.
+
+Disabled endpoints are excluded from the FastAPI router registry at startup.
+Each flag can be overridden at deployment time via the environment variable
+``TRUSTYAI_ENABLE_<FLAG_NAME>`` (upper-cased), e.g.
+``TRUSTYAI_ENABLE_DRIFT=false`` disables the entire drift group.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = frozenset({"1", "true", "yes", "on", "enabled"})
+_FALSY = frozenset({"0", "false", "no", "off", "disabled"})
+
+
+def _flag(name: str, default: bool) -> bool:
+    """Read a feature flag, allowing env-var override."""
+    env = os.getenv(f"TRUSTYAI_ENABLE_{name.upper()}")
+    if env is not None:
+        normalized = env.strip().lower()
+        if normalized in _TRUTHY:
+            return True
+        if normalized in _FALSY:
+            return False
+        logger.warning(
+            "Ignoring unrecognized value %r for TRUSTYAI_ENABLE_%s; using default %s",
+            env,
+            name.upper(),
+            default,
+        )
+    return default
+
+
+ENDPOINTS: dict[str, bool] = {
+    "fairness": _flag("fairness", True),
+    "fairness_spd": _flag("fairness_spd", True),
+    "fairness_dir": _flag("fairness_dir", True),
+    "drift": _flag("drift", True),
+    "drift_ks_test": _flag("drift_ks_test", True),
+    "drift_jensen_shannon": _flag("drift_jensen_shannon", True),
+    "drift_compare_means": _flag("drift_compare_means", True),
+    "data_download": _flag("data_download", False),
+    "explainer": _flag("explainer", False),
+    "explainer_local": _flag("explainer_local", False),
+    "explainer_global": _flag("explainer_global", False),
+}

--- a/src/trustyai_service/service/config/feature_flags.py
+++ b/src/trustyai_service/service/config/feature_flags.py
@@ -4,6 +4,10 @@ Disabled endpoints are excluded from the FastAPI router registry at startup.
 Each flag can be overridden at deployment time via the environment variable
 ``TRUSTYAI_ENABLE_<FLAG_NAME>`` (upper-cased), e.g.
 ``TRUSTYAI_ENABLE_DRIFT=false`` disables the entire drift group.
+
+``ENDPOINTS`` is evaluated once at import time. Environment variable changes
+after process start have no effect. Tests should ``patch.dict`` the
+``ENDPOINTS`` dict directly rather than mutating ``os.environ``.
 """
 
 import logging
@@ -40,6 +44,7 @@ ENDPOINTS: dict[str, bool] = {
     "drift_ks_test": _flag("drift_ks_test", default=True),
     "drift_jensen_shannon": _flag("drift_jensen_shannon", default=True),
     "drift_compare_means": _flag("drift_compare_means", default=True),
+    # Explainers default to disabled: experimental, computationally expensive
     "explainer": _flag("explainer", default=False),
     "explainer_local": _flag("explainer_local", default=False),
     "explainer_global": _flag("explainer_global", default=False),

--- a/src/trustyai_service/service/config/feature_flags.py
+++ b/src/trustyai_service/service/config/feature_flags.py
@@ -40,7 +40,6 @@ ENDPOINTS: dict[str, bool] = {
     "drift_ks_test": _flag("drift_ks_test", default=True),
     "drift_jensen_shannon": _flag("drift_jensen_shannon", default=True),
     "drift_compare_means": _flag("drift_compare_means", default=True),
-    "data_download": _flag("data_download", default=False),
     "explainer": _flag("explainer", default=False),
     "explainer_local": _flag("explainer_local", default=False),
     "explainer_global": _flag("explainer_global", default=False),

--- a/src/trustyai_service/service/config/registry.py
+++ b/src/trustyai_service/service/config/registry.py
@@ -1,11 +1,6 @@
-"""Router registration helpers with feature flag support.
-
-Disabled endpoints are excluded from the FastAPI router registry at
-startup — they do not appear in /docs and have no runtime cost.
-"""
+"""Router registration helpers with feature flag support."""
 
 import logging
-from typing import Any
 
 from fastapi import APIRouter, FastAPI
 
@@ -23,17 +18,18 @@ def register_if_enabled(
 ) -> None:
     """Conditionally register a router if the named feature flag is enabled.
 
-    Args:
-        app: FastAPI application instance.
-        router: Router to register.
-        flag: Feature flag name (must match keys in ENDPOINTS dict).
-        tag: Optional tag for OpenAPI grouping.
-        prefix: Optional URL prefix (e.g. "/metrics" for legacy endpoints).
+    :param app: FastAPI application instance.
+    :param router: Router to register.
+    :param flag: Feature flag name (must match keys in ENDPOINTS dict).
+    :param tag: Optional tag for OpenAPI grouping.
+    :param prefix: Optional URL prefix (e.g. "/metrics" for legacy endpoints).
     """
     if not ENDPOINTS.get(flag, False):
         logger.debug("Skipping router: flag '%s' is disabled", flag)
         return
-    kwargs: dict[str, Any] = {"tags": [tag]} if tag else {}
+    kwargs: dict[str, str | list[str]] = {}
+    if tag:
+        kwargs["tags"] = [tag]
     if prefix:
         kwargs["prefix"] = prefix
     app.include_router(router, **kwargs)  # type: ignore[arg-type]
@@ -49,12 +45,12 @@ def register_if_enabled_with_group(
 ) -> None:
     """Register a router gated by both a group flag and an individual metric flag.
 
-    If the group flag is disabled, the metric is never registered.
-    If the group is enabled but the individual metric flag is disabled,
-    that metric is skipped while others in the same group still register.
-
-    Example: ENDPOINTS["drift"] controls all drift metrics, while
-    ENDPOINTS["drift_jensen_shannon"] controls Jensen-Shannon specifically.
+    :param app: FastAPI application instance.
+    :param router: Router to register.
+    :param group_flag: Group-level feature flag name.
+    :param metric_flag: Individual metric feature flag name.
+    :param tag: Optional tag for OpenAPI grouping.
+    :param prefix: Optional URL prefix (e.g. "/metrics" for legacy endpoints).
     """
     if not ENDPOINTS.get(group_flag, False):
         logger.debug(
@@ -70,7 +66,9 @@ def register_if_enabled_with_group(
             metric_flag,
         )
         return
-    kwargs: dict[str, Any] = {"tags": [tag]} if tag else {}
+    kwargs: dict[str, str | list[str]] = {}
+    if tag:
+        kwargs["tags"] = [tag]
     if prefix:
         kwargs["prefix"] = prefix
     app.include_router(router, **kwargs)  # type: ignore[arg-type]

--- a/src/trustyai_service/service/config/registry.py
+++ b/src/trustyai_service/service/config/registry.py
@@ -10,7 +10,10 @@ logger = logging.getLogger(__name__)
 
 
 def _is_enabled(flag: str) -> bool:
-    return ENDPOINTS.get(flag, False)
+    if flag not in ENDPOINTS:
+        logger.warning("Unknown feature flag '%s' queried; treating as disabled", flag)
+        return False
+    return ENDPOINTS[flag]
 
 
 def _include_router(
@@ -19,12 +22,14 @@ def _include_router(
     tag: str | None = None,
     prefix: str | None = None,
 ) -> None:
-    kwargs: dict[str, str | list[str]] = {}
-    if tag:
-        kwargs["tags"] = [tag]
-    if prefix:
-        kwargs["prefix"] = prefix
-    app.include_router(router, **kwargs)  # type: ignore[arg-type]
+    if tag and prefix:
+        app.include_router(router, tags=[tag], prefix=prefix)
+    elif tag:
+        app.include_router(router, tags=[tag])
+    elif prefix:
+        app.include_router(router, prefix=prefix)
+    else:
+        app.include_router(router)
 
 
 def register_if_enabled(

--- a/src/trustyai_service/service/config/registry.py
+++ b/src/trustyai_service/service/config/registry.py
@@ -9,6 +9,24 @@ from trustyai_service.service.config.feature_flags import ENDPOINTS
 logger = logging.getLogger(__name__)
 
 
+def _is_enabled(flag: str) -> bool:
+    return ENDPOINTS.get(flag, False)
+
+
+def _include_router(
+    app: FastAPI,
+    router: APIRouter,
+    tag: str | None = None,
+    prefix: str | None = None,
+) -> None:
+    kwargs: dict[str, str | list[str]] = {}
+    if tag:
+        kwargs["tags"] = [tag]
+    if prefix:
+        kwargs["prefix"] = prefix
+    app.include_router(router, **kwargs)  # type: ignore[arg-type]
+
+
 def register_if_enabled(
     app: FastAPI,
     router: APIRouter,
@@ -24,15 +42,10 @@ def register_if_enabled(
     :param tag: Optional tag for OpenAPI grouping.
     :param prefix: Optional URL prefix (e.g. "/metrics" for legacy endpoints).
     """
-    if not ENDPOINTS.get(flag, False):
+    if not _is_enabled(flag):
         logger.debug("Skipping router: flag '%s' is disabled", flag)
         return
-    kwargs: dict[str, str | list[str]] = {}
-    if tag:
-        kwargs["tags"] = [tag]
-    if prefix:
-        kwargs["prefix"] = prefix
-    app.include_router(router, **kwargs)  # type: ignore[arg-type]
+    _include_router(app, router, tag, prefix)
 
 
 def register_if_enabled_with_group(
@@ -52,23 +65,18 @@ def register_if_enabled_with_group(
     :param tag: Optional tag for OpenAPI grouping.
     :param prefix: Optional URL prefix (e.g. "/metrics" for legacy endpoints).
     """
-    if not ENDPOINTS.get(group_flag, False):
+    if not _is_enabled(group_flag):
         logger.debug(
             "Skipping %s: group flag '%s' is disabled",
             metric_flag,
             group_flag,
         )
         return
-    if not ENDPOINTS.get(metric_flag, False):
+    if not _is_enabled(metric_flag):
         logger.debug(
             "Skipping %s: metric flag '%s' is disabled",
             metric_flag,
             metric_flag,
         )
         return
-    kwargs: dict[str, str | list[str]] = {}
-    if tag:
-        kwargs["tags"] = [tag]
-    if prefix:
-        kwargs["prefix"] = prefix
-    app.include_router(router, **kwargs)  # type: ignore[arg-type]
+    _include_router(app, router, tag, prefix)

--- a/src/trustyai_service/service/config/registry.py
+++ b/src/trustyai_service/service/config/registry.py
@@ -1,0 +1,76 @@
+"""Router registration helpers with feature flag support.
+
+Disabled endpoints are excluded from the FastAPI router registry at
+startup — they do not appear in /docs and have no runtime cost.
+"""
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, FastAPI
+
+from trustyai_service.service.config.feature_flags import ENDPOINTS
+
+logger = logging.getLogger(__name__)
+
+
+def register_if_enabled(
+    app: FastAPI,
+    router: APIRouter,
+    flag: str,
+    tag: str | None = None,
+    prefix: str | None = None,
+) -> None:
+    """Conditionally register a router if the named feature flag is enabled.
+
+    Args:
+        app: FastAPI application instance.
+        router: Router to register.
+        flag: Feature flag name (must match keys in ENDPOINTS dict).
+        tag: Optional tag for OpenAPI grouping.
+        prefix: Optional URL prefix (e.g. "/metrics" for legacy endpoints).
+    """
+    if not ENDPOINTS.get(flag, False):
+        logger.debug("Skipping router: flag '%s' is disabled", flag)
+        return
+    kwargs: dict[str, Any] = {"tags": [tag]} if tag else {}
+    if prefix:
+        kwargs["prefix"] = prefix
+    app.include_router(router, **kwargs)  # type: ignore[arg-type]
+
+
+def register_if_enabled_with_group(
+    app: FastAPI,
+    router: APIRouter,
+    group_flag: str,
+    metric_flag: str,
+    tag: str | None = None,
+    prefix: str | None = None,
+) -> None:
+    """Register a router gated by both a group flag and an individual metric flag.
+
+    If the group flag is disabled, the metric is never registered.
+    If the group is enabled but the individual metric flag is disabled,
+    that metric is skipped while others in the same group still register.
+
+    Example: ENDPOINTS["drift"] controls all drift metrics, while
+    ENDPOINTS["drift_jensen_shannon"] controls Jensen-Shannon specifically.
+    """
+    if not ENDPOINTS.get(group_flag, False):
+        logger.debug(
+            "Skipping %s: group flag '%s' is disabled",
+            metric_flag,
+            group_flag,
+        )
+        return
+    if not ENDPOINTS.get(metric_flag, False):
+        logger.debug(
+            "Skipping %s: metric flag '%s' is disabled",
+            metric_flag,
+            metric_flag,
+        )
+        return
+    kwargs: dict[str, Any] = {"tags": [tag]} if tag else {}
+    if prefix:
+        kwargs["prefix"] = prefix
+    app.include_router(router, **kwargs)  # type: ignore[arg-type]

--- a/tests/service/config/__init__.py
+++ b/tests/service/config/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for service configuration modules."""

--- a/tests/service/config/test_feature_flags.py
+++ b/tests/service/config/test_feature_flags.py
@@ -1,0 +1,91 @@
+"""Unit tests for feature_flags.py."""
+
+from unittest.mock import patch
+
+from trustyai_service.service.config.feature_flags import ENDPOINTS, _flag
+
+
+class TestEndpointFlags:
+    def test_all_flags_are_boolean(self):
+        for value in ENDPOINTS.values():
+            assert isinstance(value, bool)
+
+    def test_all_known_flags_present(self):
+        expected = {
+            "fairness",
+            "fairness_spd",
+            "fairness_dir",
+            "drift",
+            "drift_ks_test",
+            "drift_jensen_shannon",
+            "drift_compare_means",
+            "explainer",
+            "explainer_local",
+            "explainer_global",
+            "data_download",
+        }
+        assert set(ENDPOINTS.keys()) == expected
+
+
+class TestFlagEnvOverride:
+    @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "false"})
+    def test_env_disables_flag(self):
+        assert _flag("drift", True) is False
+
+    @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "true"})
+    def test_env_enables_flag(self):
+        assert _flag("drift", False) is True
+
+    @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "1"})
+    def test_env_truthy_1(self):
+        assert _flag("drift", False) is True
+
+    @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "0"})
+    def test_env_falsy_0(self):
+        assert _flag("drift", True) is False
+
+    @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "yes"})
+    def test_env_truthy_yes(self):
+        assert _flag("drift", False) is True
+
+    @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "no"})
+    def test_env_falsy_no(self):
+        assert _flag("drift", True) is False
+
+    @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "on"})
+    def test_env_truthy_on(self):
+        assert _flag("drift", False) is True
+
+    @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "off"})
+    def test_env_falsy_off(self):
+        assert _flag("drift", True) is False
+
+    @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "enabled"})
+    def test_env_truthy_enabled(self):
+        assert _flag("drift", False) is True
+
+    @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "disabled"})
+    def test_env_falsy_disabled(self):
+        assert _flag("drift", True) is False
+
+    @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "TRUE"})
+    def test_env_case_insensitive(self):
+        assert _flag("drift", False) is True
+
+    @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "  true  "})
+    def test_env_strips_whitespace(self):
+        assert _flag("drift", False) is True
+
+    @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "maybe"})
+    def test_env_unrecognized_falls_back_to_default(self):
+        assert _flag("drift", True) is True
+        assert _flag("drift", False) is False
+
+    @patch.dict("os.environ", {}, clear=False)
+    def test_no_env_uses_default(self):
+        # Ensure TRUSTYAI_ENABLE_NONEXISTENT is not set
+        import os
+
+        os.environ.pop("TRUSTYAI_ENABLE_NONEXISTENT", None)
+        assert _flag("nonexistent", True) is True
+        assert _flag("nonexistent", False) is False

--- a/tests/service/config/test_feature_flags.py
+++ b/tests/service/config/test_feature_flags.py
@@ -30,6 +30,32 @@ class TestEndpointFlags:
         }
         assert set(ENDPOINTS.keys()) == expected
 
+    def test_fairness_and_drift_default_enabled(self) -> None:
+        """Fairness and drift flags default to True (enabled)."""
+        enabled_by_default = [
+            "fairness",
+            "fairness_spd",
+            "fairness_dir",
+            "drift",
+            "drift_ks_test",
+            "drift_jensen_shannon",
+            "drift_compare_means",
+        ]
+        for flag in enabled_by_default:
+            assert _flag(flag, default=True) is True, f"{flag} should default to True"
+
+    def test_explainer_defaults_disabled(self) -> None:
+        """Explainer flags default to False (disabled, experimental)."""
+        disabled_by_default = [
+            "explainer",
+            "explainer_local",
+            "explainer_global",
+        ]
+        for flag in disabled_by_default:
+            assert _flag(flag, default=False) is False, (
+                f"{flag} should default to False"
+            )
+
 
 class TestFlagEnvOverride:
     """Tests for _flag() environment variable override logic."""

--- a/tests/service/config/test_feature_flags.py
+++ b/tests/service/config/test_feature_flags.py
@@ -27,7 +27,6 @@ class TestEndpointFlags:
             "explainer",
             "explainer_local",
             "explainer_global",
-            "data_download",
         }
         assert set(ENDPOINTS.keys()) == expected
 

--- a/tests/service/config/test_feature_flags.py
+++ b/tests/service/config/test_feature_flags.py
@@ -1,16 +1,21 @@
 """Unit tests for feature_flags.py."""
 
+import os
 from unittest.mock import patch
 
 from trustyai_service.service.config.feature_flags import ENDPOINTS, _flag
 
 
 class TestEndpointFlags:
-    def test_all_flags_are_boolean(self):
+    """Tests for the ENDPOINTS dictionary defaults."""
+
+    def test_all_flags_are_boolean(self) -> None:
+        """Every value in ENDPOINTS must be a bool."""
         for value in ENDPOINTS.values():
             assert isinstance(value, bool)
 
-    def test_all_known_flags_present(self):
+    def test_all_known_flags_present(self) -> None:
+        """ENDPOINTS must contain exactly the expected set of flag keys."""
         expected = {
             "fairness",
             "fairness_spd",
@@ -28,64 +33,76 @@ class TestEndpointFlags:
 
 
 class TestFlagEnvOverride:
+    """Tests for _flag() environment variable override logic."""
+
     @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "false"})
-    def test_env_disables_flag(self):
-        assert _flag("drift", True) is False
+    def test_env_disables_flag(self) -> None:
+        """Env var 'false' overrides default=True."""
+        assert _flag("drift", default=True) is False
 
     @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "true"})
-    def test_env_enables_flag(self):
-        assert _flag("drift", False) is True
+    def test_env_enables_flag(self) -> None:
+        """Env var 'true' overrides default=False."""
+        assert _flag("drift", default=False) is True
 
     @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "1"})
-    def test_env_truthy_1(self):
-        assert _flag("drift", False) is True
+    def test_env_truthy_1(self) -> None:
+        """Env var '1' is truthy."""
+        assert _flag("drift", default=False) is True
 
     @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "0"})
-    def test_env_falsy_0(self):
-        assert _flag("drift", True) is False
+    def test_env_falsy_0(self) -> None:
+        """Env var '0' is falsy."""
+        assert _flag("drift", default=True) is False
 
     @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "yes"})
-    def test_env_truthy_yes(self):
-        assert _flag("drift", False) is True
+    def test_env_truthy_yes(self) -> None:
+        """Env var 'yes' is truthy."""
+        assert _flag("drift", default=False) is True
 
     @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "no"})
-    def test_env_falsy_no(self):
-        assert _flag("drift", True) is False
+    def test_env_falsy_no(self) -> None:
+        """Env var 'no' is falsy."""
+        assert _flag("drift", default=True) is False
 
     @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "on"})
-    def test_env_truthy_on(self):
-        assert _flag("drift", False) is True
+    def test_env_truthy_on(self) -> None:
+        """Env var 'on' is truthy."""
+        assert _flag("drift", default=False) is True
 
     @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "off"})
-    def test_env_falsy_off(self):
-        assert _flag("drift", True) is False
+    def test_env_falsy_off(self) -> None:
+        """Env var 'off' is falsy."""
+        assert _flag("drift", default=True) is False
 
     @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "enabled"})
-    def test_env_truthy_enabled(self):
-        assert _flag("drift", False) is True
+    def test_env_truthy_enabled(self) -> None:
+        """Env var 'enabled' is truthy."""
+        assert _flag("drift", default=False) is True
 
     @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "disabled"})
-    def test_env_falsy_disabled(self):
-        assert _flag("drift", True) is False
+    def test_env_falsy_disabled(self) -> None:
+        """Env var 'disabled' is falsy."""
+        assert _flag("drift", default=True) is False
 
     @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "TRUE"})
-    def test_env_case_insensitive(self):
-        assert _flag("drift", False) is True
+    def test_env_case_insensitive(self) -> None:
+        """Env var parsing is case-insensitive."""
+        assert _flag("drift", default=False) is True
 
     @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "  true  "})
-    def test_env_strips_whitespace(self):
-        assert _flag("drift", False) is True
+    def test_env_strips_whitespace(self) -> None:
+        """Env var parsing strips surrounding whitespace."""
+        assert _flag("drift", default=False) is True
 
     @patch.dict("os.environ", {"TRUSTYAI_ENABLE_DRIFT": "maybe"})
-    def test_env_unrecognized_falls_back_to_default(self):
-        assert _flag("drift", True) is True
-        assert _flag("drift", False) is False
+    def test_env_unrecognized_falls_back_to_default(self) -> None:
+        """Unrecognized env var value falls back to the default."""
+        assert _flag("drift", default=True) is True
+        assert _flag("drift", default=False) is False
 
-    @patch.dict("os.environ", {}, clear=False)
-    def test_no_env_uses_default(self):
-        # Ensure TRUSTYAI_ENABLE_NONEXISTENT is not set
-        import os
-
+    def test_no_env_uses_default(self) -> None:
+        """Missing env var uses the provided default."""
         os.environ.pop("TRUSTYAI_ENABLE_NONEXISTENT", None)
-        assert _flag("nonexistent", True) is True
-        assert _flag("nonexistent", False) is False
+        assert _flag("nonexistent", default=True) is True
+        assert _flag("nonexistent", default=False) is False

--- a/tests/service/config/test_registry.py
+++ b/tests/service/config/test_registry.py
@@ -1,0 +1,242 @@
+"""Unit tests for registry.py."""
+
+from unittest.mock import MagicMock, patch
+
+from trustyai_service.service.config.registry import (
+    register_if_enabled,
+    register_if_enabled_with_group,
+)
+
+
+class TestRegisterIfEnabled:
+    def test_registers_router_when_flag_enabled(self):
+        app = MagicMock()
+        router = MagicMock()
+
+        with patch.dict("trustyai_service.service.config.registry.ENDPOINTS", {"fairness": True, "other": False}, clear=True):
+            register_if_enabled(app, router, "fairness", "Test Tag")
+
+        app.include_router.assert_called_once_with(router, tags=["Test Tag"])
+
+    def test_skips_router_when_flag_disabled(self):
+        app = MagicMock()
+        router = MagicMock()
+
+        with patch.dict("trustyai_service.service.config.registry.ENDPOINTS", {"fairness": False, "other": True}, clear=True):
+            register_if_enabled(app, router, "fairness", "Test Tag")
+
+        app.include_router.assert_not_called()
+
+    def test_registers_with_prefix(self):
+        app = MagicMock()
+        router = MagicMock()
+
+        with patch.dict("trustyai_service.service.config.registry.ENDPOINTS", {"fairness": True}, clear=True):
+            register_if_enabled(app, router, "fairness", prefix="/metrics")
+
+        app.include_router.assert_called_once_with(router, prefix="/metrics")
+
+    def test_registers_with_tag_and_prefix(self):
+        app = MagicMock()
+        router = MagicMock()
+
+        with patch.dict("trustyai_service.service.config.registry.ENDPOINTS", {"fairness": True}, clear=True):
+            register_if_enabled(app, router, "fairness", "Test Tag", prefix="/metrics")
+
+        app.include_router.assert_called_once_with(router, tags=["Test Tag"], prefix="/metrics")
+
+    def test_no_tag_no_prefix(self):
+        app = MagicMock()
+        router = MagicMock()
+
+        with patch.dict("trustyai_service.service.config.registry.ENDPOINTS", {"drift": True}, clear=True):
+            register_if_enabled(app, router, "drift")
+
+        app.include_router.assert_called_once_with(router)
+
+
+class TestRegisterIfEnabledWithGroup:
+    def test_registers_when_both_flags_enabled(self):
+        """Both group and metric flag enabled -> registers."""
+        app = MagicMock()
+        router = MagicMock()
+
+        with patch.dict(
+            "trustyai_service.service.config.registry.ENDPOINTS",
+            {"drift": True, "drift_jensen_shannon": True},
+            clear=True,
+        ):
+            register_if_enabled_with_group(
+                app,
+                router,
+                "drift",
+                "drift_jensen_shannon",
+                "Drift Metrics: JensenShannon",
+            )
+
+        app.include_router.assert_called_once()
+
+    def test_skips_when_group_flag_disabled(self):
+        """Group disabled -> skips regardless of metric flag."""
+        app = MagicMock()
+        router = MagicMock()
+
+        with patch.dict(
+            "trustyai_service.service.config.registry.ENDPOINTS",
+            {"drift": False, "drift_jensen_shannon": True},
+            clear=True,
+        ):
+            register_if_enabled_with_group(
+                app,
+                router,
+                "drift",
+                "drift_jensen_shannon",
+                "Drift Metrics: JensenShannon",
+            )
+
+        app.include_router.assert_not_called()
+
+    def test_skips_when_metric_flag_disabled(self):
+        """Group enabled but metric flag disabled -> skips just that metric."""
+        app = MagicMock()
+        router = MagicMock()
+
+        with patch.dict(
+            "trustyai_service.service.config.registry.ENDPOINTS",
+            {"drift": True, "drift_jensen_shannon": False},
+            clear=True,
+        ):
+            register_if_enabled_with_group(
+                app,
+                router,
+                "drift",
+                "drift_jensen_shannon",
+                "Drift Metrics: JensenShannon",
+            )
+
+        app.include_router.assert_not_called()
+
+    def test_other_metrics_still_register_when_one_is_disabled(self):
+        """Disabling one metric doesn't affect other metrics in the same group."""
+        app = MagicMock()
+        ks_router = MagicMock()
+        js_router = MagicMock()
+
+        with patch.dict(
+            "trustyai_service.service.config.registry.ENDPOINTS",
+            {"drift": True, "drift_ks_test": True, "drift_jensen_shannon": False},
+            clear=True,
+        ):
+            register_if_enabled_with_group(
+                app,
+                ks_router,
+                "drift",
+                "drift_ks_test",
+                "Drift Metrics: KSTest",
+            )
+            register_if_enabled_with_group(
+                app,
+                js_router,
+                "drift",
+                "drift_jensen_shannon",
+                "Drift Metrics: JensenShannon",
+            )
+
+        # KS-Test registered
+        app.include_router.assert_any_call(ks_router, tags=["Drift Metrics: KSTest"])
+        # Jensen-Shannon skipped (called once for KS-Test only)
+        assert app.include_router.call_count == 1
+
+    def test_registers_with_prefix(self):
+        app = MagicMock()
+        router = MagicMock()
+
+        with patch.dict(
+            "trustyai_service.service.config.registry.ENDPOINTS",
+            {"fairness": True, "fairness_spd": True},
+            clear=True,
+        ):
+            register_if_enabled_with_group(
+                app,
+                router,
+                "fairness",
+                "fairness_spd",
+                prefix="/metrics",
+            )
+
+        app.include_router.assert_called_once_with(router, prefix="/metrics")
+
+    def test_registers_with_tag_and_prefix(self):
+        app = MagicMock()
+        router = MagicMock()
+
+        with patch.dict(
+            "trustyai_service.service.config.registry.ENDPOINTS",
+            {"fairness": True, "fairness_dir": True},
+            clear=True,
+        ):
+            register_if_enabled_with_group(
+                app,
+                router,
+                "fairness",
+                "fairness_dir",
+                "Fairness: DIR",
+                prefix="/metrics",
+            )
+
+        app.include_router.assert_called_once_with(
+            router,
+            tags=["Fairness: DIR"],
+            prefix="/metrics",
+        )
+
+    def test_explainer_group_gates_individual_metrics(self):
+        """Group disabled -> explainers skipped regardless of individual flags."""
+        app = MagicMock()
+        router = MagicMock()
+
+        with patch.dict(
+            "trustyai_service.service.config.registry.ENDPOINTS",
+            {"explainer": False, "explainer_local": True},
+            clear=True,
+        ):
+            register_if_enabled_with_group(
+                app,
+                router,
+                "explainer",
+                "explainer_local",
+                "Explainers: Local",
+            )
+
+        app.include_router.assert_not_called()
+
+    def test_explainer_individual_flag_gates_specific_explainer(self):
+        """Group enabled but individual flag disabled -> skips just that explainer."""
+        app = MagicMock()
+        local_router = MagicMock()
+        global_router = MagicMock()
+
+        with patch.dict(
+            "trustyai_service.service.config.registry.ENDPOINTS",
+            {"explainer": True, "explainer_local": False, "explainer_global": True},
+            clear=True,
+        ):
+            register_if_enabled_with_group(
+                app,
+                local_router,
+                "explainer",
+                "explainer_local",
+                "Explainers: Local",
+            )
+            register_if_enabled_with_group(
+                app,
+                global_router,
+                "explainer",
+                "explainer_global",
+                "Explainers: Global",
+            )
+
+        # Global registered
+        app.include_router.assert_any_call(global_router, tags=["Explainers: Global"])
+        # Local skipped (called once for Global only)
+        assert app.include_router.call_count == 1

--- a/tests/service/config/test_registry.py
+++ b/tests/service/config/test_registry.py
@@ -9,54 +9,85 @@ from trustyai_service.service.config.registry import (
 
 
 class TestRegisterIfEnabled:
-    def test_registers_router_when_flag_enabled(self):
+    """Tests for single-flag router registration."""
+
+    def test_registers_router_when_flag_enabled(self) -> None:
+        """Router is included when its flag is True."""
         app = MagicMock()
         router = MagicMock()
 
-        with patch.dict("trustyai_service.service.config.registry.ENDPOINTS", {"fairness": True, "other": False}, clear=True):
+        with patch.dict(
+            "trustyai_service.service.config.registry.ENDPOINTS",
+            {"fairness": True, "other": False},
+            clear=True,
+        ):
             register_if_enabled(app, router, "fairness", "Test Tag")
 
         app.include_router.assert_called_once_with(router, tags=["Test Tag"])
 
-    def test_skips_router_when_flag_disabled(self):
+    def test_skips_router_when_flag_disabled(self) -> None:
+        """Router is skipped when its flag is False."""
         app = MagicMock()
         router = MagicMock()
 
-        with patch.dict("trustyai_service.service.config.registry.ENDPOINTS", {"fairness": False, "other": True}, clear=True):
+        with patch.dict(
+            "trustyai_service.service.config.registry.ENDPOINTS",
+            {"fairness": False, "other": True},
+            clear=True,
+        ):
             register_if_enabled(app, router, "fairness", "Test Tag")
 
         app.include_router.assert_not_called()
 
-    def test_registers_with_prefix(self):
+    def test_registers_with_prefix(self) -> None:
+        """Router receives prefix kwarg when specified."""
         app = MagicMock()
         router = MagicMock()
 
-        with patch.dict("trustyai_service.service.config.registry.ENDPOINTS", {"fairness": True}, clear=True):
+        with patch.dict(
+            "trustyai_service.service.config.registry.ENDPOINTS",
+            {"fairness": True},
+            clear=True,
+        ):
             register_if_enabled(app, router, "fairness", prefix="/metrics")
 
         app.include_router.assert_called_once_with(router, prefix="/metrics")
 
-    def test_registers_with_tag_and_prefix(self):
+    def test_registers_with_tag_and_prefix(self) -> None:
+        """Router receives both tag and prefix kwargs."""
         app = MagicMock()
         router = MagicMock()
 
-        with patch.dict("trustyai_service.service.config.registry.ENDPOINTS", {"fairness": True}, clear=True):
+        with patch.dict(
+            "trustyai_service.service.config.registry.ENDPOINTS",
+            {"fairness": True},
+            clear=True,
+        ):
             register_if_enabled(app, router, "fairness", "Test Tag", prefix="/metrics")
 
-        app.include_router.assert_called_once_with(router, tags=["Test Tag"], prefix="/metrics")
+        app.include_router.assert_called_once_with(
+            router, tags=["Test Tag"], prefix="/metrics"
+        )
 
-    def test_no_tag_no_prefix(self):
+    def test_no_tag_no_prefix(self) -> None:
+        """Router is registered with no extra kwargs when tag and prefix are omitted."""
         app = MagicMock()
         router = MagicMock()
 
-        with patch.dict("trustyai_service.service.config.registry.ENDPOINTS", {"drift": True}, clear=True):
+        with patch.dict(
+            "trustyai_service.service.config.registry.ENDPOINTS",
+            {"drift": True},
+            clear=True,
+        ):
             register_if_enabled(app, router, "drift")
 
         app.include_router.assert_called_once_with(router)
 
 
 class TestRegisterIfEnabledWithGroup:
-    def test_registers_when_both_flags_enabled(self):
+    """Tests for group-gated router registration."""
+
+    def test_registers_when_both_flags_enabled(self) -> None:
         """Both group and metric flag enabled -> registers."""
         app = MagicMock()
         router = MagicMock()
@@ -76,7 +107,7 @@ class TestRegisterIfEnabledWithGroup:
 
         app.include_router.assert_called_once()
 
-    def test_skips_when_group_flag_disabled(self):
+    def test_skips_when_group_flag_disabled(self) -> None:
         """Group disabled -> skips regardless of metric flag."""
         app = MagicMock()
         router = MagicMock()
@@ -96,7 +127,7 @@ class TestRegisterIfEnabledWithGroup:
 
         app.include_router.assert_not_called()
 
-    def test_skips_when_metric_flag_disabled(self):
+    def test_skips_when_metric_flag_disabled(self) -> None:
         """Group enabled but metric flag disabled -> skips just that metric."""
         app = MagicMock()
         router = MagicMock()
@@ -116,7 +147,7 @@ class TestRegisterIfEnabledWithGroup:
 
         app.include_router.assert_not_called()
 
-    def test_other_metrics_still_register_when_one_is_disabled(self):
+    def test_other_metrics_still_register_when_one_is_disabled(self) -> None:
         """Disabling one metric doesn't affect other metrics in the same group."""
         app = MagicMock()
         ks_router = MagicMock()
@@ -142,12 +173,11 @@ class TestRegisterIfEnabledWithGroup:
                 "Drift Metrics: JensenShannon",
             )
 
-        # KS-Test registered
         app.include_router.assert_any_call(ks_router, tags=["Drift Metrics: KSTest"])
-        # Jensen-Shannon skipped (called once for KS-Test only)
         assert app.include_router.call_count == 1
 
-    def test_registers_with_prefix(self):
+    def test_registers_with_prefix(self) -> None:
+        """Router receives prefix kwarg when specified."""
         app = MagicMock()
         router = MagicMock()
 
@@ -166,7 +196,8 @@ class TestRegisterIfEnabledWithGroup:
 
         app.include_router.assert_called_once_with(router, prefix="/metrics")
 
-    def test_registers_with_tag_and_prefix(self):
+    def test_registers_with_tag_and_prefix(self) -> None:
+        """Router receives both tag and prefix when specified."""
         app = MagicMock()
         router = MagicMock()
 
@@ -190,7 +221,7 @@ class TestRegisterIfEnabledWithGroup:
             prefix="/metrics",
         )
 
-    def test_explainer_group_gates_individual_metrics(self):
+    def test_explainer_group_gates_individual_metrics(self) -> None:
         """Group disabled -> explainers skipped regardless of individual flags."""
         app = MagicMock()
         router = MagicMock()
@@ -210,7 +241,7 @@ class TestRegisterIfEnabledWithGroup:
 
         app.include_router.assert_not_called()
 
-    def test_explainer_individual_flag_gates_specific_explainer(self):
+    def test_explainer_individual_flag_gates_specific_explainer(self) -> None:
         """Group enabled but individual flag disabled -> skips just that explainer."""
         app = MagicMock()
         local_router = MagicMock()
@@ -236,7 +267,5 @@ class TestRegisterIfEnabledWithGroup:
                 "Explainers: Global",
             )
 
-        # Global registered
         app.include_router.assert_any_call(global_router, tags=["Explainers: Global"])
-        # Local skipped (called once for Global only)
         assert app.include_router.call_count == 1

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -1,10 +1,25 @@
 """Integration tests for main application endpoint registration."""
 
 from http import HTTPStatus
+from unittest.mock import patch
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from trustyai_service.endpoints.metrics.drift.compare_means import (
+    router as drift_comparemeans_router,
+)
+from trustyai_service.endpoints.metrics.drift.jensen_shannon import (
+    router as drift_jensenshannon_router,
+)
+from trustyai_service.endpoints.metrics.drift.kolmogorov_smirnov import (
+    router as drift_kstest_router,
+)
+from trustyai_service.endpoints.metrics.fairness.group.dir import router as dir_router
+from trustyai_service.endpoints.metrics.fairness.group.spd import router as spd_router
 from trustyai_service.main import app
+from trustyai_service.service.config.feature_flags import ENDPOINTS
+from trustyai_service.service.config.registry import register_if_enabled_with_group
 
 client = TestClient(app)
 
@@ -232,49 +247,109 @@ class TestCompareMeansMetricIntegration:
         assert meanshift_list.get("deprecated") is True
 
 
-class TestFourierMMDMetricIntegration:
-    """Integration tests for FourierMMD drift metric registration."""
+def _build_app_with_flags(overrides: dict[str, bool]) -> FastAPI:
+    """Build a minimal FastAPI app with custom feature flag overrides.
 
-    def test_fouriermmd_endpoints_in_openapi(self) -> None:
-        """FourierMMD endpoints are registered in OpenAPI."""
-        response = client.get("/openapi.json")
-        openapi = response.json()
-        for path in [
-            "/metrics/drift/fouriermmd",
-            "/metrics/drift/fouriermmd/definition",
-            "/metrics/drift/fouriermmd/request",
-            "/metrics/drift/fouriermmd/requests",
-        ]:
-            assert path in openapi["paths"], f"{path} not found in OpenAPI"
+    Constructs a fresh app and registers drift/fairness routers using
+    the same ``register_if_enabled_with_group`` helper that ``src/main.py``
+    uses, but with patched flags.
+    """
+    test_app = FastAPI()
+    patched = {**ENDPOINTS, **overrides}
+
+    with patch.dict("trustyai_service.service.config.registry.ENDPOINTS", patched, clear=True):
+        register_if_enabled_with_group(
+            test_app,
+            dir_router,
+            "fairness",
+            "fairness_dir",
+            "Fairness: DIR",
+        )
+        register_if_enabled_with_group(
+            test_app,
+            spd_router,
+            "fairness",
+            "fairness_spd",
+            "Fairness: SPD",
+        )
+        register_if_enabled_with_group(
+            test_app,
+            drift_comparemeans_router,
+            "drift",
+            "drift_compare_means",
+            "Drift: CompareMeans",
+        )
+        register_if_enabled_with_group(
+            test_app,
+            drift_kstest_router,
+            "drift",
+            "drift_ks_test",
+            "Drift: KSTest",
+        )
+        register_if_enabled_with_group(
+            test_app,
+            drift_jensenshannon_router,
+            "drift",
+            "drift_jensen_shannon",
+            "Drift: JensenShannon",
+        )
+        register_if_enabled_with_group(
+            test_app,
+            dir_router,
+            "fairness",
+            "fairness_dir",
+            prefix="/metrics",
+            tag="{Legacy}: DIR",
+        )
+        register_if_enabled_with_group(
+            test_app,
+            spd_router,
+            "fairness",
+            "fairness_spd",
+            prefix="/metrics",
+            tag="{Legacy}: SPD",
+        )
+
+    return test_app
 
 
-class TestApproxKSTestMetricIntegration:
-    """Integration tests for ApproxKSTest drift metric registration."""
+class TestFeatureFlagGating:
+    """Verify that disabling a feature flag removes endpoints from OpenAPI."""
 
-    def test_approxkstest_endpoints_in_openapi(self) -> None:
-        """ApproxKSTest endpoints are registered in OpenAPI."""
-        response = client.get("/openapi.json")
-        openapi = response.json()
-        for path in [
-            "/metrics/drift/approxkstest",
-            "/metrics/drift/approxkstest/definition",
-            "/metrics/drift/approxkstest/request",
-            "/metrics/drift/approxkstest/requests",
-        ]:
-            assert path in openapi["paths"], f"{path} not found in OpenAPI"
+    def test_disabling_fairness_removes_dir_and_spd(self) -> None:
+        """Setting fairness=False removes all fairness endpoints."""
+        test_app = _build_app_with_flags({"fairness": False})
+        test_client = TestClient(test_app)
 
+        response = test_client.get("/openapi.json")
+        assert response.status_code == HTTPStatus.OK
+        paths = response.json()["paths"]
 
-class TestJensenShannonMetricIntegration:
-    """Integration tests for JensenShannon drift metric registration."""
+        fairness_paths = [
+            p for p in paths if "/fairness/" in p or "/dir" in p or "/spd" in p
+        ]
+        assert fairness_paths == []
 
-    def test_jensenshannon_endpoints_in_openapi(self) -> None:
-        """JensenShannon endpoints are registered in OpenAPI."""
-        response = client.get("/openapi.json")
-        openapi = response.json()
-        for path in [
-            "/metrics/drift/jensenshannon",
-            "/metrics/drift/jensenshannon/definition",
-            "/metrics/drift/jensenshannon/request",
-            "/metrics/drift/jensenshannon/requests",
-        ]:
-            assert path in openapi["paths"], f"{path} not found in OpenAPI"
+    def test_disabling_drift_removes_all_drift_endpoints(self) -> None:
+        """Setting drift=False removes KSTest, CompareMeans, and JensenShannon."""
+        test_app = _build_app_with_flags({"drift": False})
+        test_client = TestClient(test_app)
+
+        response = test_client.get("/openapi.json")
+        assert response.status_code == HTTPStatus.OK
+        paths = response.json()["paths"]
+
+        drift_paths = [p for p in paths if "/metrics/drift/" in p]
+        assert drift_paths == []
+
+    def test_disabling_individual_metric_keeps_others(self) -> None:
+        """Disabling drift_ks_test removes KS but keeps CompareMeans."""
+        test_app = _build_app_with_flags({"drift_ks_test": False})
+        test_client = TestClient(test_app)
+
+        response = test_client.get("/openapi.json")
+        assert response.status_code == HTTPStatus.OK
+        paths = response.json()["paths"]
+
+        assert "/metrics/drift/kstest" not in paths
+        assert "/metrics/drift/comparemeans" in paths

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -257,7 +257,9 @@ def _build_app_with_flags(overrides: dict[str, bool]) -> FastAPI:
     test_app = FastAPI()
     patched = {**ENDPOINTS, **overrides}
 
-    with patch.dict("trustyai_service.service.config.registry.ENDPOINTS", patched, clear=True):
+    with patch.dict(
+        "trustyai_service.service.config.registry.ENDPOINTS", patched, clear=True
+    ):
         register_if_enabled_with_group(
             test_app,
             dir_router,
@@ -326,7 +328,7 @@ class TestFeatureFlagGating:
         paths = response.json()["paths"]
 
         fairness_paths = [
-            p for p in paths if "/fairness/" in p or "/dir" in p or "/spd" in p
+            p for p in paths if p.startswith(("/dir", "/spd")) or "/fairness/" in p
         ]
         assert fairness_paths == []
 

--- a/uv.lock
+++ b/uv.lock
@@ -2093,7 +2093,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3281,6 +3281,7 @@ wheels = [
 
 [[package]]
 name = "trustyai-service"
+version = "1.0.0rc0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -3344,7 +3345,7 @@ types = [
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=48.0.1,<50" },
-    { name = "fastapi", specifier = ">=0.116,<0.140" },
+    { name = "fastapi", specifier = ">=0.116,<0.138" },
     { name = "fastapi-utils", specifier = ">=0.8,<0.9" },
     { name = "h5py", specifier = ">=3.13,<4" },
     { name = "hypercorn", specifier = ">=0.18,<0.19" },
@@ -3352,7 +3353,7 @@ requires-dist = [
     { name = "javaobj-py3", marker = "extra == 'mariadb'", specifier = ">=0.5,<0.6" },
     { name = "lm-eval", extras = ["api"], marker = "extra == 'eval'", specifier = ">=0.4,<0.5" },
     { name = "mariadb", marker = "extra == 'mariadb'", specifier = ">=1.1,<1.2" },
-    { name = "nltk", marker = "extra == 'eval'", specifier = ">=3.10.0,<4" },
+    { name = "nltk", marker = "extra == 'eval'", specifier = ">=3.9.4,<4" },
     { name = "numpy", specifier = ">=2.0,<3" },
     { name = "pandas", specifier = ">=3.0,<4" },
     { name = "polars", specifier = ">=1.2,<2" },
@@ -3383,7 +3384,7 @@ notebook = [
 test = [
     { name = "aif360", specifier = ">=0.6.1" },
     { name = "hypothesis", specifier = ">=6.151.12" },
-    { name = "pillow", specifier = ">=12.3.0" },
+    { name = "pillow", specifier = ">=12.2.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },


### PR DESCRIPTION
## Summary
- 82 tests (62 PVC + 20 MariaDB mocked) covering dataset CRUD, serialization edge cases, void type compatibility, name mapping, partial payloads, SSL configuration, and error paths
- Raises PVC coverage from 55% to 91%
- Documents pre-existing bug in `pvc.py:get_metadata()` (passes kwargs to StorageMetadata instead of StorageMetadataConfig)

## Test plan
- [x] All 82 tests pass locally
- [x] CI passes

Ref: RHOAIENG-71282

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable feature flags for controlling drift, fairness, and explainer endpoints.
  * Added environment-variable overrides for enabling or disabling endpoint groups and individual metrics.
  * Disabled explainer endpoints by default while keeping drift and fairness endpoints enabled.
  * Updated API documentation to reflect only currently enabled endpoints.

* **Tests**
  * Added coverage for flag parsing, endpoint registration, and grouped feature-flag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->