### PR TITLE
fix(ci): use commit SHA for codeql-action pin

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -97,7 +97,7 @@ jobs:
           vuln-type: 'os,library'
 
       - name: Update Security tab
-        uses: github/codeql-action/upload-sarif@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'trivy-release-scan'

--- a/.github/workflows/ci-publish.yaml
+++ b/.github/workflows/ci-publish.yaml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Update Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'trivy-ci-scan'

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -29,6 +29,6 @@ jobs:
           name: SARIF file
           path: results.sarif
           retention-days: 5
-      - uses: github/codeql-action/upload-sarif@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
+      - uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload SARIF results to GitHub Security tab
         if: github.ref == 'refs/heads/main'
-        uses: github/codeql-action/upload-sarif@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: results.sarif
           category: bandit-security-scan


### PR DESCRIPTION
## Summary
- Fix OpenSSF Scorecard workflow failure caused by pinning `github/codeql-action/upload-sarif` to an annotated tag object SHA instead of the underlying commit SHA
- The v3 tag object (`b0c4fd7...`) is not in the commit history, so the Scorecard webapp rejects it as an "imposter commit"
- Replace with the dereferenced commit SHA (`dd903d2...`) across all 4 workflow files that use `codeql-action/upload-sarif`

## Root cause
PR #203 pinned `github/codeql-action/upload-sarif@v3` by SHA. The `v3` tag is an annotated tag — `git ls-remote` returns the tag object SHA, not the commit. The OpenSSF Scorecard webapp validates that all action SHAs in the workflow are actual commits in the referenced repository, and tag object SHAs fail this check.

## Files changed
- `.github/workflows/scorecard.yaml`
- `.github/workflows/security-scan.yaml`
- `.github/workflows/build-and-push.yaml`
- `.github/workflows/ci-publish.yaml`

## Test plan
- [ ] Scorecard workflow passes after merge ([failed run](https://github.com/trustyai-explainability/trustyai-service/actions/runs/28123853097/job/83282475110))
- [ ] Other CI workflows using `codeql-action/upload-sarif` continue to work

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned version of the GitHub Security tab upload action in several automated workflows.
  * No changes to workflow behavior, inputs, or security scan results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->