### PR TITLE
ci: add upstream tag to release image builds

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -36,12 +36,12 @@ jobs:
             VERSION="${REF_NAME#v}"
             # Sanitize for OCI image tag: replace + with - (OCI tags: [a-zA-Z0-9._-])
             SANITIZED_TAG="${REF_NAME//+/-}"
-            echo "tags=${SANITIZED_TAG} latest" >> "$GITHUB_OUTPUT"
+            echo "tags=${SANITIZED_TAG} latest upstream" >> "$GITHUB_OUTPUT"
             echo "primary_tag=${SANITIZED_TAG}" >> "$GITHUB_OUTPUT"
             echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           else
-            # Push only latest for main branch
-            echo "tags=latest" >> "$GITHUB_OUTPUT"
+            # Push latest and upstream for main branch
+            echo "tags=latest upstream" >> "$GITHUB_OUTPUT"
             echo "primary_tag=latest" >> "$GITHUB_OUTPUT"
             echo "version=0.0.0.dev0" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary

- Adds `upstream` tag alongside `latest` for both main branch pushes and version tag releases
- Also updates `QUAY_RELEASE_REPO` variable (done separately in repo settings) from `quay.io/trustyai/trustyai-service-python` to `quay.io/trustyai/trustyai-service`

## Test plan

- [ ] Verify next push to main publishes image with both `latest` and `upstream` tags
- [ ] Verify tag push publishes image with version, `latest`, and `upstream` tags

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated published image tags to include an additional `upstream` tag for both versioned releases and non-versioned builds.
  * Builds from release tags now continue to publish `latest` alongside the release tag and `upstream`.
  * Builds from the main branch now publish both `latest` and `upstream` tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->