### PR TITLE
chore(container): pin base image to SHA256 digest

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,7 +10,7 @@ ARG ENABLE_FIPS_POLICY="true"
 # =============================================================================
 # Stage 1: Builder — UBI10 Python 3.14 minimal with dev tools
 # =============================================================================
-FROM registry.access.redhat.com/ubi10/python-314-minimal:latest AS builder
+FROM registry.access.redhat.com/ubi10/python-314-minimal@sha256:0d6de003c233849fc6690277d18b66a2f0217b6c8c447c074462aa22267b6982 AS builder
 
 ARG EXTRAS
 
@@ -49,7 +49,7 @@ RUN mkdir -p src && \
 # =============================================================================
 # Stage 2: Runtime — UBI10 Python 3.14 minimal (no compilers, no dev headers)
 # =============================================================================
-FROM registry.access.redhat.com/ubi10/python-314-minimal:latest
+FROM registry.access.redhat.com/ubi10/python-314-minimal@sha256:0d6de003c233849fc6690277d18b66a2f0217b6c8c447c074462aa22267b6982
 
 ARG EXTRAS
 ARG VERSION


### PR DESCRIPTION
## Summary

Pin `ubi10/python-314-minimal` FROM directives in the Containerfile to the manifest list SHA256 digest instead of the `:latest` tag.

This is required for downstream Renovate to automatically detect and update base image digests.

## Details

- Digest `sha256:0d6de003c233849fc6690277d18b66a2f0217b6c8c447c074462aa22267b6982` is the multi-arch manifest list (resolves to the correct architecture at pull time)
- Both builder and runtime stages pinned to the same digest

## Test plan
- [x] CI container build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s base container image to a fixed, immutable version for more consistent and reliable builds.
  * This helps reduce unexpected changes from upstream image updates without affecting how the app runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->