### PR TITLE
feat(ci): improve OpenSSF Scorecard (SAST + token permissions)

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -16,6 +16,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: read-all
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -14,6 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-publish.yaml
+++ b/.github/workflows/ci-publish.yaml
@@ -5,6 +5,8 @@ on:
     workflows: ["CI Build"]
     types: [completed]
 
+permissions: read-all
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -12,6 +12,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   bandit-scan:
     runs-on: ubuntu-latest
@@ -57,3 +59,15 @@ jobs:
           path: results.sarif
           retention-days: 30
         continue-on-error: true
+
+  codeql:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          languages: python
+      - uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3


### PR DESCRIPTION
## Summary
- Add CodeQL static analysis as a parallel job in `security-scan.yaml` (SAST check: 0 → 10)
- Add top-level `permissions: read-all` to all workflows missing it (Token-Permissions check: 8 → 10)

## Context
Current OpenSSF scorecard report: https://scorecard.dev/viewer/?uri=github.com/trustyai-explainability/trustyai-service

## Files changed
- `.github/workflows/security-scan.yaml` — new `codeql` job + top-level permissions
- `.github/workflows/build-and-push.yaml` — top-level permissions
- `.github/workflows/ci-build.yaml` — top-level permissions
- `.github/workflows/ci-publish.yaml` — top-level permissions

## Test plan
- [ ] CodeQL job runs successfully on this PR
- [ ] Bandit job continues to pass (unmodified)
- [ ] Other CI workflows unaffected (job-level permissions override top-level)
- [ ] After merge, Scorecard SAST and Token-Permissions checks improve

Generated with [Claude Code](https://claude.com/claude-code)