### PR TITLE
[WIP] [DO_NOT_MERGE] refactor(dataframe): adopt Narwhals as DataFrame abstraction layer

### DIFF
--- a/TEST_FIXES_SUMMARY.md
+++ b/TEST_FIXES_SUMMARY.md
@@ -1,0 +1,122 @@
+# Test Fixes Summary
+
+## Problem Overview
+
+PR #166 (feat/pvc-to-database-migration) had 5 failing tests after CodeRabbit's review fix in commit `b6f4671`. The failures revealed two systemic issues in the test suite.
+
+## Root Causes
+
+### 1. Fragile Mock Pattern in test_pvc_migration.py
+
+**Issue:** Tests used brittle `side_effect` lists that broke when implementation changed:
+
+```python
+# BEFORE: Hard-coded list of return values
+mock_cursor.fetchone.side_effect = [
+    None,  # migration not complete
+    (1,),  # file already migrated
+]
+# If code adds another fetchone() call → StopIteration error
+```
+
+**Why it broke:** CodeRabbit added resume logic that made an extra `fetchone()` call:
+```python
+# New code in _start_migration_tracking (lines 182-189)
+cursor.execute(
+    "SELECT id, total_files FROM trustyai_migration_status "
+    "WHERE status=? ..."
+)
+result = cursor.fetchone()  # <-- NEW call, exhausted mock side_effect
+```
+
+**Fix:** Replaced with semantic mocks that return values based on query content:
+```python
+# AFTER: Query-aware mock function
+def mock_fetchone(*args, **kwargs):
+    if mock_cursor.execute.call_args:
+        call_args = mock_cursor.execute.call_args[0]
+        # Return based on WHAT is queried, not call order
+        if "trustyai_migration_status" in call_args[0] and "IN_PROGRESS" in str(call_args):
+            return None  # No in-progress migration
+        if "trustyai_file_migration_status" in call_args[0]:
+            return None  # File not yet migrated
+    return None
+```
+
+**Benefits:**
+- Survives implementation changes (adding/removing queries)
+- Self-documenting (shows intent: "what query returns what value")
+- More maintainable
+
+### 2. Inconsistent Prometheus Counter Naming
+
+**Issue:** Counters had inconsistent naming that caused confusion:
+
+```python
+# BEFORE: Some had _total, some didn't
+migration_files_total = Counter("trustyai_migration_files_total", ...)      # has _total
+migration_files_success = Counter("trustyai_migration_files_success", ...)  # no _total
+migration_rows_total = Counter("trustyai_migration_rows_total", ...)        # has _total
+migration_files_failed = Counter("trustyai_migration_files_failed", ...)    # no _total
+```
+
+**Prometheus behavior:**
+- Counters WITHOUT `_total` in name → Prometheus ADDS `_total` suffix
+- Counters WITH `_total` in name → Prometheus does NOT add another suffix
+
+**Result:** Inconsistent metric names exposed to Prometheus:
+- `trustyai_migration_files_total` (no suffix added)
+- `trustyai_migration_files_success_total` (suffix added)
+- `trustyai_migration_rows_total` (no suffix added)
+- `trustyai_migration_files_failed_total` (suffix added)
+
+**Fix:** Removed `_total` from all Counter names, let Prometheus add it consistently:
+
+```python
+# AFTER: All consistent, Prometheus adds _total to all
+migration_files = Counter("trustyai_migration_files", ...)
+migration_files_success = Counter("trustyai_migration_files_success", ...)
+migration_files_failed = Counter("trustyai_migration_files_failed", ...)
+migration_rows = Counter("trustyai_migration_rows", ...)
+```
+
+**Result:** All metrics now consistently have `_total` suffix:
+- `trustyai_migration_files_total`
+- `trustyai_migration_files_success_total`
+- `trustyai_migration_files_failed_total`
+- `trustyai_migration_rows_total`
+
+## Files Modified
+
+### Source Code
+- `src/service/data/storage/maria/pvc_migration.py`
+  - Renamed counters: `migration_files_total` → `migration_files`, `migration_rows_total` → `migration_rows`
+  - Updated all `.inc()` calls
+
+### Tests
+- `tests/service/data/storage/maria/test_pvc_migration.py`
+  - Refactored 3 tests to use semantic mocks instead of side_effect lists:
+    - `test_migrate_with_file_failure`
+    - `test_migrate_resume_skips_completed_files`
+    - `test_start_migration_tracking` (already correct, verified)
+
+- `tests/service/data/storage/maria/test_timeout_and_metrics.py`
+  - Updated metric names to use consistent `_total` suffix
+  - Improved comments explaining Prometheus behavior
+  - Already used semantic mocks (good pattern)
+
+## Verification
+
+All 43 tests pass:
+```bash
+uv run pytest tests/service/data/storage/maria/test_pvc_migration.py \
+             tests/service/data/storage/maria/test_timeout_and_metrics.py -v
+# ============================== 43 passed in 2.88s ==============================
+```
+
+## Lessons Learned
+
+1. **Use semantic mocks:** Mock return values based on query content, not execution order
+2. **Follow library conventions:** Let Prometheus add metric suffixes, don't do it manually
+3. **Test isolation:** Tests should survive implementation changes that don't change semantics
+4. **Code review impact:** External review tools can introduce changes that break fragile tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "prometheus-client>=0.22,<0.26",
     "pydantic>=2.13,<3",
     "hypercorn>=0.18,<0.19",
-    "protobuf>=7,<8",        # Security: Resolves CVE-2026-0994 (HIGH - Buffer overflow)
     "cryptography>=48.0.1,<50",  # Security: Resolves CVE-2026-26007 (HIGH)
     "h5py>=3.13,<4",
     "isodate>=0.7,<0.8",
@@ -59,7 +58,6 @@ eval = [
     "nltk>=3.10.0,<4",        # Security: Resolves CVE-2025-14009 (CRITICAL - Zip Slip), CVE-2026-33236, CVE-2026-33231 (HIGH), and 2 MEDIUM
     "sqlitedict>=2.1,<3",    # Security: Resolves CVE-2024-35515 (HIGH)
 ]
-# Note: grpcio/grpcio-tools removed - incompatible with protobuf v7, unused (protoc used instead)
 mariadb = ["mariadb>=1.1,<1.2", "javaobj-py3>=0.5,<0.6"]
 
 [tool.hatch.version]
@@ -84,7 +82,6 @@ requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.ruff]
-# Exclude generated protobuf files from all ruff operations
 exclude = ["src/trustyai_service/proto/grpc_predict_v2_pb2.py", "src/trustyai_service/_version.py"]
 
 [tool.ruff.lint]
@@ -126,9 +123,9 @@ ignore = [
 "tests/endpoints/metrics/drift/factory.py" = ["PLR0913", "C901", "PLR0915"]
 "tests/endpoints/test_upload_endpoint_maria.py" = ["S105"]
 "tests/endpoints/test_upload_endpoint_pvc.py" = ["PLR0913"]
-"tests/service/data/test_utils.py" = ["PLR0913", "UP037"]  # UP037: Keep quoted annotations for optional protobuf imports
 "tests/service/serialization/test_rows.py" = ["PLR2004"]
 "tests/service/data/storage/maria/*.py" = ["ANN", "PLR2004", "ARG002"]  # Pytest style: no test method annotations, exact assertion values, setup-only fixtures
+"tests/service/data/test_utils.py" = ["PLR0913", "UP037"]  # UP037: Keep quoted annotations for optional protobuf imports
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
@@ -165,8 +162,6 @@ ignore-missing-imports = [
     "pytest.*",
     "hypothesis.*",
     "matplotlib.*",
-    # Generated protobuf - excluded from analysis but imported optionally in tests
-    "trustyai_service.proto.grpc_predict_v2_pb2.*",
 ]
 
 # Broad suppressions for pre-existing type issues.
@@ -269,6 +264,7 @@ not-iterable = "ignore"
 # Suppress h5py/numpy type issues in PVC storage
 [[tool.pyrefly.sub-config]]
 matches = "src/trustyai_service/service/data/storage/pvc.py"
+"src/trustyai_service/service/data/storage/maria/maria.py" = ["ASYNC240"]  # One-time startup PVC check via Path.exists/is_dir/glob (local mount, negligible blocking)
 
 [tool.pyrefly.sub-config.errors]
 unsupported-operation = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trustyai-service"
-version = "1.0.0rc0"
+dynamic = ["version"]
 description = "TrustyAI Service"
 authors = [{ name = "Rui Vieira" }, { name = "TrustyAI team" }]
 requires-python = ">=3.12, <3.15"
@@ -11,7 +11,7 @@ dependencies = [
     "numpy>=2.0,<3",
     "pandas>=3.0,<4",
     "polars>=1.2,<2",
-    "fastapi>=0.116,<0.138",
+    "fastapi>=0.116,<0.140",
     "fastapi-utils>=0.8,<0.9",
     "uvicorn>=0.38,<1",
     "typing-inspect>=0.9,<1",
@@ -45,7 +45,7 @@ test = [
     "pytest-xdist[psutil]>=3.8.0",
     "hypothesis>=6.151.12",
     "aif360>=0.6.1",
-    "pillow>=12.2.0",        # Security: Resolves CVE-2026-25990 (HIGH - Out-of-bounds write)
+    "pillow>=12.3.0",        # Security: Resolves CVE-2026-25990 (HIGH - Out-of-bounds write)
 ]
 notebook = [
     "ipykernel>=7.2.0",
@@ -56,25 +56,36 @@ notebook = [
 [project.optional-dependencies]
 eval = [
     "lm-eval[api]>=0.4,<0.5",
-    "nltk>=3.9.4,<4",        # Security: Resolves CVE-2025-14009 (CRITICAL - Zip Slip), CVE-2026-33236, CVE-2026-33231 (HIGH), and 2 MEDIUM
+    "nltk>=3.10.0,<4",        # Security: Resolves CVE-2025-14009 (CRITICAL - Zip Slip), CVE-2026-33236, CVE-2026-33231 (HIGH), and 2 MEDIUM
     "sqlitedict>=2.1,<3",    # Security: Resolves CVE-2024-35515 (HIGH)
 ]
 # Note: grpcio/grpcio-tools removed - incompatible with protobuf v7, unused (protoc used instead)
 mariadb = ["mariadb>=1.1,<1.2", "javaobj-py3>=0.5,<0.6"]
 
+[tool.hatch.version]
+source = "vcs"
+fallback-version = "0.0.0.dev0"
+
+[tool.hatch.version.raw-options]
+version_scheme = "no-guess-dev"
+local_scheme = "dirty-tag"
+
 [tool.hatch.build.targets.sdist]
-include = ["src"]
+packages = ["src/trustyai_service"]
 
 [tool.hatch.build.targets.wheel]
-include = ["src"]
+packages = ["src/trustyai_service"]
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/trustyai_service/_version.py"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.ruff]
 # Exclude generated protobuf files from all ruff operations
-exclude = ["src/proto/grpc_predict_v2_pb2.py"]
+exclude = ["src/trustyai_service/proto/grpc_predict_v2_pb2.py", "src/trustyai_service/_version.py"]
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -87,37 +98,37 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 # === SRC FILES ===
-"src/core/metrics/drift/jensen_shannon.py" = ["PLR0913"]
-"src/core/metrics/fairness/group/*.py" = ["PLR0913"]
-"src/middleware/gzip_middleware.py" = ["C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915"]
-"src/service/data/datasources/data_source.py" = ["BLE001", "C901", "PLR0912"]
-"src/service/data/modelmesh_parser.py" = ["PLR0913"]
-"src/service/data/storage/**/*.py" = ["SLF001", "BLE001", "PLR0913"]
-"src/service/data/storage/pvc.py" = ["C901", "PLR0912", "PLR0915", "ASYNC240", "PTH110"]
-"src/service/data/storage/maria/maria.py" = ["ASYNC240"]  # One-time startup PVC check via Path.exists/is_dir/glob (local mount, negligible blocking)
-"src/service/payloads/**/*.py" = ["SLF001"]
-"src/service/payloads/metrics/request_reconciler.py" = ["C901", "PLR0912", "PLR0915"]
-"src/service/prometheus/prometheus_publisher.py" = ["SLF001"]
-"src/service/prometheus/prometheus_scheduler.py" = ["BLE001"]
-"src/endpoints/consumer/*.py" = ["N815"]
-"src/endpoints/consumer/__init__.py" = ["C901"]
-"src/endpoints/consumer/consumer_endpoint.py" = ["BLE001", "C901", "PLR0912", "PLR0913", "PLR0915"]
-"src/endpoints/evaluation/lm_evaluation_harness.py" = ["SLF001"]
-"src/endpoints/explainers/*.py" = ["N815"]
-"src/endpoints/metadata.py" = ["N815", "BLE001", "C901"]
-"src/endpoints/metrics/**/*.py" = ["N815"]
-"src/endpoints/metrics/fairness/group/*.py" = ["BLE001", "TRY300", "TRY301"]
-"src/endpoints/metrics/drift/jensen_shannon.py" = ["TRY300", "TRY301"]
-"src/endpoints/metrics/drift/compare_means.py" = ["C901", "TRY301"]
+"src/trustyai_service/core/metrics/drift/jensen_shannon.py" = ["PLR0913"]
+"src/trustyai_service/core/metrics/fairness/group/*.py" = ["PLR0913"]
+"src/trustyai_service/middleware/gzip_middleware.py" = ["C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915"]
+"src/trustyai_service/service/data/datasources/data_source.py" = ["BLE001", "C901", "PLR0912"]
+"src/trustyai_service/service/data/modelmesh_parser.py" = ["PLR0913"]
+"src/trustyai_service/service/data/storage/**/*.py" = ["SLF001", "BLE001", "PLR0913"]
+"src/trustyai_service/service/data/storage/pvc.py" = ["C901", "PLR0912", "PLR0915", "ASYNC240", "PTH110"]
+"src/trustyai_service/service/data/storage/maria/maria.py" = ["ASYNC240"]  # One-time startup PVC check via Path.exists/is_dir/glob (local mount, negligible blocking)
+"src/trustyai_service/service/payloads/**/*.py" = ["SLF001"]
+"src/trustyai_service/service/payloads/metrics/request_reconciler.py" = ["C901", "PLR0912", "PLR0915"]
+"src/trustyai_service/service/prometheus/prometheus_publisher.py" = ["SLF001"]
+"src/trustyai_service/service/prometheus/prometheus_scheduler.py" = ["BLE001"]
+"src/trustyai_service/endpoints/consumer/*.py" = ["N815"]
+"src/trustyai_service/endpoints/consumer/__init__.py" = ["C901"]
+"src/trustyai_service/endpoints/consumer/consumer_endpoint.py" = ["BLE001", "C901", "PLR0912", "PLR0913", "PLR0915"]
+"src/trustyai_service/endpoints/evaluation/lm_evaluation_harness.py" = ["SLF001"]
+"src/trustyai_service/endpoints/explainers/*.py" = ["N815"]
+"src/trustyai_service/endpoints/metadata.py" = ["N815", "BLE001", "C901"]
+"src/trustyai_service/endpoints/metrics/**/*.py" = ["N815"]
+"src/trustyai_service/endpoints/metrics/fairness/group/*.py" = ["BLE001", "TRY300", "TRY301"]
+"src/trustyai_service/endpoints/metrics/drift/jensen_shannon.py" = ["TRY300", "TRY301"]
+"src/trustyai_service/endpoints/metrics/drift/compare_means.py" = ["C901", "TRY301"]
 # === TEST FILES ===
 "tests/**" = ["S101", "PT019", "SLF001"]
-"tests/service/data/storage/maria/*.py" = ["ANN", "PLR2004", "ARG002"]  # Pytest style: no test method annotations, exact assertion values, setup-only fixtures
 "tests/core/metrics/test_fairness.py" = ["N803", "N806"]
 "tests/endpoints/metrics/drift/factory.py" = ["PLR0913", "C901", "PLR0915"]
 "tests/endpoints/test_upload_endpoint_maria.py" = ["S105"]
 "tests/endpoints/test_upload_endpoint_pvc.py" = ["PLR0913"]
 "tests/service/data/test_utils.py" = ["PLR0913", "UP037"]  # UP037: Keep quoted annotations for optional protobuf imports
 "tests/service/serialization/test_rows.py" = ["PLR2004"]
+"tests/service/data/storage/maria/*.py" = ["ANN", "PLR2004", "ARG002"]  # Pytest style: no test method annotations, exact assertion values, setup-only fixtures
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
@@ -127,13 +138,14 @@ addopts = "--dist=loadgroup -n 4"
 [tool.bandit]
 exclude_dirs = ["tests/"]
 skips = [
-    "B104",  # hardcoded_bind_all_interfaces - intentional for service binding (src/main.py)
-    "B108",  # hardcoded_tmp_directory - system temp dir usage (src/service/data/storage/__init__.py)
+    "B104",  # hardcoded_bind_all_interfaces - intentional for service binding (src/trustyai_service/main.py)
+    "B108",  # hardcoded_tmp_directory - system temp dir usage (src/trustyai_service/service/data/storage/__init__.py)
     "B608",  # hardcoded_sql_expressions - false positives from table name construction in MariaDB storage (uses parameterized queries for actual data)
 ]
 
 [tool.pyrefly]
-project-excludes = ["**/proto/**", "src/proto/**", "src/proto/grpc_predict_v2_pb2.py"]
+search-path = ["."]
+project-excludes = ["**/proto/**", "src/trustyai_service/proto/**", "src/trustyai_service/proto/grpc_predict_v2_pb2.py", "src/trustyai_service/_version.py"]
 disable-project-excludes-heuristics = true
 # Forward-looking: pyrefly uses this for type checking, not runtime
 python-version = "3.14.0"
@@ -160,7 +172,7 @@ ignore-missing-imports = [
 # Broad suppressions for pre-existing type issues.
 # Will be tightened as code PRs fix root causes.
 [[tool.pyrefly.sub-config]]
-matches = "src/**/*.py"
+matches = "src/trustyai_service/**/*.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
@@ -197,7 +209,7 @@ unsupported-operation = "ignore"
 
 # Suppress sklearn mixin false positives in fairness metrics
 [[tool.pyrefly.sub-config]]
-matches = "src/core/metrics/fairness/**"
+matches = "src/trustyai_service/core/metrics/fairness/**"
 
 [tool.pyrefly.sub-config.errors]
 missing-attribute = "ignore"
@@ -219,7 +231,7 @@ missing-attribute = "ignore"
 no-access = "ignore"
 
 [[tool.pyrefly.sub-config]]
-matches = "src/service/payloads/metrics/request_reconciler.py"  # Schema_item validated before use (false positive)
+matches = "src/trustyai_service/service/payloads/metrics/request_reconciler.py"  # Schema_item validated before use (false positive)
 
 [tool.pyrefly.sub-config.errors]
 missing-attribute = "ignore"
@@ -233,7 +245,7 @@ bad-argument-type = "ignore"
 
 # Suppress Pydantic Field() default overrides in metric requests
 [[tool.pyrefly.sub-config]]
-matches = "src/endpoints/metrics/**/*.py"
+matches = "src/trustyai_service/endpoints/metrics/**/*.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-override = "ignore"
@@ -243,7 +255,7 @@ missing-attribute = "ignore"
 
 # Suppress storage interface implementation signature differences
 [[tool.pyrefly.sub-config]]
-matches = "src/service/data/storage/**/*.py"
+matches = "src/trustyai_service/service/data/storage/**/*.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-override = "ignore"
@@ -256,7 +268,7 @@ not-iterable = "ignore"
 
 # Suppress h5py/numpy type issues in PVC storage
 [[tool.pyrefly.sub-config]]
-matches = "src/service/data/storage/pvc.py"
+matches = "src/trustyai_service/service/data/storage/pvc.py"
 
 [tool.pyrefly.sub-config.errors]
 unsupported-operation = "ignore"
@@ -269,7 +281,7 @@ bad-param-name-override = "ignore"
 
 # Suppress evaluation harness dynamic model issues
 [[tool.pyrefly.sub-config]]
-matches = "src/endpoints/evaluation/lm_evaluation_harness.py"
+matches = "src/trustyai_service/endpoints/evaluation/lm_evaluation_harness.py"
 
 [tool.pyrefly.sub-config.errors]
 no-matching-overload = "ignore"
@@ -279,7 +291,7 @@ missing-attribute = "ignore"
 # Suppress consumer endpoint union type validation issues
 # Runtime validation narrows union types before calling functions
 [[tool.pyrefly.sub-config]]
-matches = "src/endpoints/consumer/consumer_endpoint.py"
+matches = "src/trustyai_service/endpoints/consumer/consumer_endpoint.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
@@ -293,7 +305,7 @@ missing-attribute = "ignore"
 
 # Suppress subprocess and config dict issues in main
 [[tool.pyrefly.sub-config]]
-matches = "src/main.py"
+matches = "src/trustyai_service/main.py"
 
 [tool.pyrefly.sub-config.errors]
 missing-attribute = "ignore"
@@ -301,35 +313,35 @@ unsupported-operation = "ignore"
 
 # Suppress metadata endpoint config issues
 [[tool.pyrefly.sub-config]]
-matches = "src/endpoints/metadata.py"
+matches = "src/trustyai_service/endpoints/metadata.py"
 
 [tool.pyrefly.sub-config.errors]
 unsupported-operation = "ignore"
 
 # Suppress model data tuple return type issues
 [[tool.pyrefly.sub-config]]
-matches = "src/service/data/model_data.py"
+matches = "src/trustyai_service/service/data/model_data.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-return = "ignore"
 
 # Suppress legacy maria reader pandas Index issues
 [[tool.pyrefly.sub-config]]
-matches = "src/service/data/storage/maria/legacy_maria_reader.py"
+matches = "src/trustyai_service/service/data/storage/maria/legacy_maria_reader.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
 
 # Suppress storage init int conversion issues
 [[tool.pyrefly.sub-config]]
-matches = "src/service/data/storage/__init__.py"
+matches = "src/trustyai_service/service/data/storage/__init__.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
 
 # Suppress typed value optional return types
 [[tool.pyrefly.sub-config]]
-matches = "src/service/payloads/values/typed_value.py"
+matches = "src/trustyai_service/service/payloads/values/typed_value.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-return = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trustyai-service"
-dynamic = ["version"]
+version = "1.0.0rc0"
 description = "TrustyAI Service"
 authors = [{ name = "Rui Vieira" }, { name = "TrustyAI team" }]
 requires-python = ">=3.12, <3.15"
@@ -11,7 +11,7 @@ dependencies = [
     "numpy>=2.0,<3",
     "pandas>=3.0,<4",
     "polars>=1.2,<2",
-    "fastapi>=0.116,<0.140",
+    "fastapi>=0.116,<0.138",
     "fastapi-utils>=0.8,<0.9",
     "uvicorn>=0.38,<1",
     "typing-inspect>=0.9,<1",
@@ -45,7 +45,7 @@ test = [
     "pytest-xdist[psutil]>=3.8.0",
     "hypothesis>=6.151.12",
     "aif360>=0.6.1",
-    "pillow>=12.3.0",        # Security: Resolves CVE-2026-25990 (HIGH - Out-of-bounds write)
+    "pillow>=12.2.0",        # Security: Resolves CVE-2026-25990 (HIGH - Out-of-bounds write)
 ]
 notebook = [
     "ipykernel>=7.2.0",
@@ -56,36 +56,25 @@ notebook = [
 [project.optional-dependencies]
 eval = [
     "lm-eval[api]>=0.4,<0.5",
-    "nltk>=3.10.0,<4",        # Security: Resolves CVE-2025-14009 (CRITICAL - Zip Slip), CVE-2026-33236, CVE-2026-33231 (HIGH), and 2 MEDIUM
+    "nltk>=3.9.4,<4",        # Security: Resolves CVE-2025-14009 (CRITICAL - Zip Slip), CVE-2026-33236, CVE-2026-33231 (HIGH), and 2 MEDIUM
     "sqlitedict>=2.1,<3",    # Security: Resolves CVE-2024-35515 (HIGH)
 ]
 # Note: grpcio/grpcio-tools removed - incompatible with protobuf v7, unused (protoc used instead)
 mariadb = ["mariadb>=1.1,<1.2", "javaobj-py3>=0.5,<0.6"]
 
-[tool.hatch.version]
-source = "vcs"
-fallback-version = "0.0.0.dev0"
-
-[tool.hatch.version.raw-options]
-version_scheme = "no-guess-dev"
-local_scheme = "dirty-tag"
-
 [tool.hatch.build.targets.sdist]
-packages = ["src/trustyai_service"]
+include = ["src"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/trustyai_service"]
-
-[tool.hatch.build.hooks.vcs]
-version-file = "src/trustyai_service/_version.py"
+include = ["src"]
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.ruff]
 # Exclude generated protobuf files from all ruff operations
-exclude = ["src/trustyai_service/proto/grpc_predict_v2_pb2.py", "src/trustyai_service/_version.py"]
+exclude = ["src/proto/grpc_predict_v2_pb2.py"]
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -98,29 +87,31 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 # === SRC FILES ===
-"src/trustyai_service/core/metrics/drift/jensen_shannon.py" = ["PLR0913"]
-"src/trustyai_service/core/metrics/fairness/group/*.py" = ["PLR0913"]
-"src/trustyai_service/middleware/gzip_middleware.py" = ["C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915"]
-"src/trustyai_service/service/data/datasources/data_source.py" = ["BLE001", "C901", "PLR0912"]
-"src/trustyai_service/service/data/modelmesh_parser.py" = ["PLR0913"]
-"src/trustyai_service/service/data/storage/**/*.py" = ["SLF001", "BLE001", "PLR0913"]
-"src/trustyai_service/service/data/storage/pvc.py" = ["C901", "PLR0912", "PLR0915", "ASYNC240", "PTH110"]
-"src/trustyai_service/service/payloads/**/*.py" = ["SLF001"]
-"src/trustyai_service/service/payloads/metrics/request_reconciler.py" = ["C901", "PLR0912", "PLR0915"]
-"src/trustyai_service/service/prometheus/prometheus_publisher.py" = ["SLF001"]
-"src/trustyai_service/service/prometheus/prometheus_scheduler.py" = ["BLE001"]
-"src/trustyai_service/endpoints/consumer/*.py" = ["N815"]
-"src/trustyai_service/endpoints/consumer/__init__.py" = ["C901"]
-"src/trustyai_service/endpoints/consumer/consumer_endpoint.py" = ["BLE001", "C901", "PLR0912", "PLR0913", "PLR0915"]
-"src/trustyai_service/endpoints/evaluation/lm_evaluation_harness.py" = ["SLF001"]
-"src/trustyai_service/endpoints/explainers/*.py" = ["N815"]
-"src/trustyai_service/endpoints/metadata.py" = ["N815", "BLE001", "C901"]
-"src/trustyai_service/endpoints/metrics/**/*.py" = ["N815"]
-"src/trustyai_service/endpoints/metrics/fairness/group/*.py" = ["BLE001", "TRY300", "TRY301"]
-"src/trustyai_service/endpoints/metrics/drift/jensen_shannon.py" = ["TRY300", "TRY301"]
-"src/trustyai_service/endpoints/metrics/drift/compare_means.py" = ["C901", "TRY301"]
+"src/core/metrics/drift/jensen_shannon.py" = ["PLR0913"]
+"src/core/metrics/fairness/group/*.py" = ["PLR0913"]
+"src/middleware/gzip_middleware.py" = ["C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915"]
+"src/service/data/datasources/data_source.py" = ["BLE001", "C901", "PLR0912"]
+"src/service/data/modelmesh_parser.py" = ["PLR0913"]
+"src/service/data/storage/**/*.py" = ["SLF001", "BLE001", "PLR0913"]
+"src/service/data/storage/pvc.py" = ["C901", "PLR0912", "PLR0915", "ASYNC240", "PTH110"]
+"src/service/data/storage/maria/maria.py" = ["ASYNC240"]  # One-time startup PVC check via Path.exists/is_dir/glob (local mount, negligible blocking)
+"src/service/payloads/**/*.py" = ["SLF001"]
+"src/service/payloads/metrics/request_reconciler.py" = ["C901", "PLR0912", "PLR0915"]
+"src/service/prometheus/prometheus_publisher.py" = ["SLF001"]
+"src/service/prometheus/prometheus_scheduler.py" = ["BLE001"]
+"src/endpoints/consumer/*.py" = ["N815"]
+"src/endpoints/consumer/__init__.py" = ["C901"]
+"src/endpoints/consumer/consumer_endpoint.py" = ["BLE001", "C901", "PLR0912", "PLR0913", "PLR0915"]
+"src/endpoints/evaluation/lm_evaluation_harness.py" = ["SLF001"]
+"src/endpoints/explainers/*.py" = ["N815"]
+"src/endpoints/metadata.py" = ["N815", "BLE001", "C901"]
+"src/endpoints/metrics/**/*.py" = ["N815"]
+"src/endpoints/metrics/fairness/group/*.py" = ["BLE001", "TRY300", "TRY301"]
+"src/endpoints/metrics/drift/jensen_shannon.py" = ["TRY300", "TRY301"]
+"src/endpoints/metrics/drift/compare_means.py" = ["C901", "TRY301"]
 # === TEST FILES ===
 "tests/**" = ["S101", "PT019", "SLF001"]
+"tests/service/data/storage/maria/*.py" = ["ANN", "PLR2004", "ARG002"]  # Pytest style: no test method annotations, exact assertion values, setup-only fixtures
 "tests/core/metrics/test_fairness.py" = ["N803", "N806"]
 "tests/endpoints/metrics/drift/factory.py" = ["PLR0913", "C901", "PLR0915"]
 "tests/endpoints/test_upload_endpoint_maria.py" = ["S105"]
@@ -136,14 +127,13 @@ addopts = "--dist=loadgroup -n 4"
 [tool.bandit]
 exclude_dirs = ["tests/"]
 skips = [
-    "B104",  # hardcoded_bind_all_interfaces - intentional for service binding (src/trustyai_service/main.py)
-    "B108",  # hardcoded_tmp_directory - system temp dir usage (src/trustyai_service/service/data/storage/__init__.py)
+    "B104",  # hardcoded_bind_all_interfaces - intentional for service binding (src/main.py)
+    "B108",  # hardcoded_tmp_directory - system temp dir usage (src/service/data/storage/__init__.py)
     "B608",  # hardcoded_sql_expressions - false positives from table name construction in MariaDB storage (uses parameterized queries for actual data)
 ]
 
 [tool.pyrefly]
-search-path = ["."]
-project-excludes = ["**/proto/**", "src/trustyai_service/proto/**", "src/trustyai_service/proto/grpc_predict_v2_pb2.py", "src/trustyai_service/_version.py"]
+project-excludes = ["**/proto/**", "src/proto/**", "src/proto/grpc_predict_v2_pb2.py"]
 disable-project-excludes-heuristics = true
 # Forward-looking: pyrefly uses this for type checking, not runtime
 python-version = "3.14.0"
@@ -170,7 +160,7 @@ ignore-missing-imports = [
 # Broad suppressions for pre-existing type issues.
 # Will be tightened as code PRs fix root causes.
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/**/*.py"
+matches = "src/**/*.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
@@ -207,7 +197,7 @@ unsupported-operation = "ignore"
 
 # Suppress sklearn mixin false positives in fairness metrics
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/core/metrics/fairness/**"
+matches = "src/core/metrics/fairness/**"
 
 [tool.pyrefly.sub-config.errors]
 missing-attribute = "ignore"
@@ -229,7 +219,7 @@ missing-attribute = "ignore"
 no-access = "ignore"
 
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/service/payloads/metrics/request_reconciler.py"  # Schema_item validated before use (false positive)
+matches = "src/service/payloads/metrics/request_reconciler.py"  # Schema_item validated before use (false positive)
 
 [tool.pyrefly.sub-config.errors]
 missing-attribute = "ignore"
@@ -243,7 +233,7 @@ bad-argument-type = "ignore"
 
 # Suppress Pydantic Field() default overrides in metric requests
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/endpoints/metrics/**/*.py"
+matches = "src/endpoints/metrics/**/*.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-override = "ignore"
@@ -253,7 +243,7 @@ missing-attribute = "ignore"
 
 # Suppress storage interface implementation signature differences
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/service/data/storage/**/*.py"
+matches = "src/service/data/storage/**/*.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-override = "ignore"
@@ -266,7 +256,7 @@ not-iterable = "ignore"
 
 # Suppress h5py/numpy type issues in PVC storage
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/service/data/storage/pvc.py"
+matches = "src/service/data/storage/pvc.py"
 
 [tool.pyrefly.sub-config.errors]
 unsupported-operation = "ignore"
@@ -279,7 +269,7 @@ bad-param-name-override = "ignore"
 
 # Suppress evaluation harness dynamic model issues
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/endpoints/evaluation/lm_evaluation_harness.py"
+matches = "src/endpoints/evaluation/lm_evaluation_harness.py"
 
 [tool.pyrefly.sub-config.errors]
 no-matching-overload = "ignore"
@@ -289,7 +279,7 @@ missing-attribute = "ignore"
 # Suppress consumer endpoint union type validation issues
 # Runtime validation narrows union types before calling functions
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/endpoints/consumer/consumer_endpoint.py"
+matches = "src/endpoints/consumer/consumer_endpoint.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
@@ -303,7 +293,7 @@ missing-attribute = "ignore"
 
 # Suppress subprocess and config dict issues in main
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/main.py"
+matches = "src/main.py"
 
 [tool.pyrefly.sub-config.errors]
 missing-attribute = "ignore"
@@ -311,35 +301,35 @@ unsupported-operation = "ignore"
 
 # Suppress metadata endpoint config issues
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/endpoints/metadata.py"
+matches = "src/endpoints/metadata.py"
 
 [tool.pyrefly.sub-config.errors]
 unsupported-operation = "ignore"
 
 # Suppress model data tuple return type issues
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/service/data/model_data.py"
+matches = "src/service/data/model_data.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-return = "ignore"
 
 # Suppress legacy maria reader pandas Index issues
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/service/data/storage/maria/legacy_maria_reader.py"
+matches = "src/service/data/storage/maria/legacy_maria_reader.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
 
 # Suppress storage init int conversion issues
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/service/data/storage/__init__.py"
+matches = "src/service/data/storage/__init__.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-argument-type = "ignore"
 
 # Suppress typed value optional return types
 [[tool.pyrefly.sub-config]]
-matches = "src/trustyai_service/service/payloads/values/typed_value.py"
+matches = "src/service/payloads/values/typed_value.py"
 
 [tool.pyrefly.sub-config.errors]
 bad-return = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,12 @@ dependencies = [
     "pandas>=3.0,<4",
     "polars>=1.2,<2",
     "fastapi>=0.116,<0.140",
-    "fastapi-utils>=0.8,<0.9",
     "uvicorn>=0.38,<1",
     "typing-inspect>=0.9,<1",
     "prometheus-client>=0.22,<0.26",
     "pydantic>=2.13,<3",
     "hypercorn>=0.18,<0.19",
+    "protobuf>=7,<8",        # Security: Resolves CVE-2026-0994 (HIGH - Buffer overflow)
     "cryptography>=48.0.1,<50",  # Security: Resolves CVE-2026-26007 (HIGH)
     "h5py>=3.13,<4",
     "isodate>=0.7,<0.8",
@@ -58,6 +58,7 @@ eval = [
     "nltk>=3.10.0,<4",        # Security: Resolves CVE-2025-14009 (CRITICAL - Zip Slip), CVE-2026-33236, CVE-2026-33231 (HIGH), and 2 MEDIUM
     "sqlitedict>=2.1,<3",    # Security: Resolves CVE-2024-35515 (HIGH)
 ]
+# Note: grpcio/grpcio-tools removed - incompatible with protobuf v7, unused (protoc used instead)
 mariadb = ["mariadb>=1.1,<1.2", "javaobj-py3>=0.5,<0.6"]
 
 [tool.hatch.version]
@@ -82,6 +83,7 @@ requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.ruff]
+# Exclude generated protobuf files from all ruff operations
 exclude = ["src/trustyai_service/proto/grpc_predict_v2_pb2.py", "src/trustyai_service/_version.py"]
 
 [tool.ruff.lint]
@@ -123,9 +125,9 @@ ignore = [
 "tests/endpoints/metrics/drift/factory.py" = ["PLR0913", "C901", "PLR0915"]
 "tests/endpoints/test_upload_endpoint_maria.py" = ["S105"]
 "tests/endpoints/test_upload_endpoint_pvc.py" = ["PLR0913"]
+"tests/service/data/test_utils.py" = ["PLR0913", "UP037"]  # UP037: Keep quoted annotations for optional protobuf imports
 "tests/service/serialization/test_rows.py" = ["PLR2004"]
 "tests/service/data/storage/maria/*.py" = ["ANN", "PLR2004", "ARG002"]  # Pytest style: no test method annotations, exact assertion values, setup-only fixtures
-"tests/service/data/test_utils.py" = ["PLR0913", "UP037"]  # UP037: Keep quoted annotations for optional protobuf imports
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
@@ -149,7 +151,6 @@ python-version = "3.14.0"
 ignore-missing-imports = [
     "aif360.*",
     "fastapi.*",
-    "fastapi_utils.*",
     "hypercorn.*",
     "isodate.*",
     "javaobj.*",
@@ -162,6 +163,8 @@ ignore-missing-imports = [
     "pytest.*",
     "hypothesis.*",
     "matplotlib.*",
+    # Generated protobuf - excluded from analysis but imported optionally in tests
+    "trustyai_service.proto.grpc_predict_v2_pb2.*",
 ]
 
 # Broad suppressions for pre-existing type issues.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ python-version = "3.14.0"
 ignore-missing-imports = [
     "aif360.*",
     "fastapi.*",
+    "fastapi_utils.*",
     "hypercorn.*",
     "isodate.*",
     "javaobj.*",

--- a/src/trustyai_service/main.py
+++ b/src/trustyai_service/main.py
@@ -33,8 +33,17 @@ from trustyai_service.endpoints.explainers.local_explainer import (
 )
 from trustyai_service.endpoints.metadata import router as metadata_router
 from trustyai_service.endpoints.metrics.batch_mean import router as batch_mean_router
+from trustyai_service.endpoints.metrics.drift.approx_ks_test import (
+    router as drift_approxkstest_router,
+)
 from trustyai_service.endpoints.metrics.drift.compare_means import (
     router as drift_comparemeans_router,
+)
+from trustyai_service.endpoints.metrics.drift.fourier_mmd import (
+    router as drift_fouriermmd_router,
+)
+from trustyai_service.endpoints.metrics.drift.jensen_shannon import (
+    router as drift_jensenshannon_router,
 )
 from trustyai_service.endpoints.metrics.drift.kolmogorov_smirnov import (
     router as drift_kstest_router,
@@ -180,6 +189,18 @@ app.include_router(
     tags=[
         "Drift Metrics: CompareMeans",
     ],
+)
+app.include_router(
+    drift_fouriermmd_router,
+    tags=["Drift Metrics: FourierMMD"],
+)
+app.include_router(
+    drift_approxkstest_router,
+    tags=["Drift Metrics: ApproxKSTest"],
+)
+app.include_router(
+    drift_jensenshannon_router,
+    tags=["Drift Metrics: JensenShannon"],
 )
 app.include_router(
     drift_kstest_router,

--- a/src/trustyai_service/main.py
+++ b/src/trustyai_service/main.py
@@ -21,19 +21,29 @@ from hypercorn.config import Config
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 # Endpoint routers
-from trustyai_service.endpoints.consumer.consumer_endpoint import router as consumer_router
+from trustyai_service.endpoints.consumer.consumer_endpoint import (
+    router as consumer_router,
+)
 from trustyai_service.endpoints.data.data_upload import router as data_upload_router
-from trustyai_service.endpoints.explainers.global_explainer import router as explainers_global_router
-from trustyai_service.endpoints.explainers.local_explainer import router as explainers_local_router
+from trustyai_service.endpoints.explainers.global_explainer import (
+    router as explainers_global_router,
+)
+from trustyai_service.endpoints.explainers.local_explainer import (
+    router as explainers_local_router,
+)
 from trustyai_service.endpoints.metadata import router as metadata_router
 from trustyai_service.endpoints.metrics.batch_mean import router as batch_mean_router
 from trustyai_service.endpoints.metrics.drift.compare_means import (
     router as drift_comparemeans_router,
 )
-from trustyai_service.endpoints.metrics.drift.kolmogorov_smirnov import router as drift_kstest_router
+from trustyai_service.endpoints.metrics.drift.kolmogorov_smirnov import (
+    router as drift_kstest_router,
+)
 from trustyai_service.endpoints.metrics.fairness.group.dir import router as dir_router
 from trustyai_service.endpoints.metrics.fairness.group.spd import router as spd_router
-from trustyai_service.endpoints.metrics.metrics_info import router as metrics_info_router
+from trustyai_service.endpoints.metrics.metrics_info import (
+    router as metrics_info_router,
+)
 
 # Middleware
 from trustyai_service.middleware.gzip_middleware import GzipRequestMiddleware
@@ -81,7 +91,9 @@ logging.getLogger("hypercorn.protocol").setLevel(logging.INFO)
 logging.getLogger("hypercorn.access").setLevel(logging.INFO)
 
 # Ensure scheduler debug logging
-scheduler_logger = logging.getLogger("trustyai_service.service.prometheus.prometheus_scheduler")
+scheduler_logger = logging.getLogger(
+    "trustyai_service.service.prometheus.prometheus_scheduler"
+)
 scheduler_logger.setLevel(logging.DEBUG)
 logger = logging.getLogger(__name__)
 
@@ -331,6 +343,16 @@ async def readiness_probe() -> JSONResponse:
                             if response is not None:
                                 return response
                             # Migration complete - proceed to ready state
+                        else:
+                            # No migration row exists yet - migration not started
+                            # Treat as not ready to prevent traffic before migration begins
+                            return JSONResponse(
+                                content={
+                                    "status": "not_ready",
+                                    "reason": "Migration not started yet",
+                                },
+                                status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+                            )
 
             except Exception as e:
                 # If we can't check migration status, assume not ready

--- a/src/trustyai_service/main.py
+++ b/src/trustyai_service/main.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import os
+import time
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from http import HTTPStatus
@@ -10,8 +11,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from fastapi import FastAPI, Request, Response
-
-from trustyai_service import __version__
 
 if TYPE_CHECKING:
     from fastapi import APIRouter
@@ -22,44 +21,34 @@ from hypercorn.config import Config
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 # Endpoint routers
-from trustyai_service.endpoints.consumer.consumer_endpoint import (
-    router as consumer_router,
-)
+from trustyai_service.endpoints.consumer.consumer_endpoint import router as consumer_router
 from trustyai_service.endpoints.data.data_upload import router as data_upload_router
-from trustyai_service.endpoints.explainers.global_explainer import (
-    router as explainers_global_router,
-)
-from trustyai_service.endpoints.explainers.local_explainer import (
-    router as explainers_local_router,
-)
+from trustyai_service.endpoints.explainers.global_explainer import router as explainers_global_router
+from trustyai_service.endpoints.explainers.local_explainer import router as explainers_local_router
 from trustyai_service.endpoints.metadata import router as metadata_router
 from trustyai_service.endpoints.metrics.batch_mean import router as batch_mean_router
-from trustyai_service.endpoints.metrics.drift.approx_ks_test import (
-    router as drift_approxkstest_router,
-)
 from trustyai_service.endpoints.metrics.drift.compare_means import (
     router as drift_comparemeans_router,
 )
-from trustyai_service.endpoints.metrics.drift.fourier_mmd import (
-    router as drift_fouriermmd_router,
-)
-from trustyai_service.endpoints.metrics.drift.jensen_shannon import (
-    router as drift_jensenshannon_router,
-)
-from trustyai_service.endpoints.metrics.drift.kolmogorov_smirnov import (
-    router as drift_kstest_router,
-)
+from trustyai_service.endpoints.metrics.drift.kolmogorov_smirnov import router as drift_kstest_router
 from trustyai_service.endpoints.metrics.fairness.group.dir import router as dir_router
 from trustyai_service.endpoints.metrics.fairness.group.spd import router as spd_router
-from trustyai_service.endpoints.metrics.metrics_info import (
-    router as metrics_info_router,
-)
+from trustyai_service.endpoints.metrics.metrics_info import router as metrics_info_router
 
 # Middleware
 from trustyai_service.middleware.gzip_middleware import GzipRequestMiddleware
+from trustyai_service.service.data.storage.maria.pvc_migration import (
+    MIGRATION_STATUS_COMPLETE,
+    MIGRATION_STATUS_FAILED,
+    MIGRATION_STATUS_IN_PROGRESS,
+    MIGRATION_STATUS_PARTIAL,
+)
 from trustyai_service.service.prometheus.shared_prometheus_scheduler import (
     get_shared_prometheus_scheduler,
 )
+
+# Valid storage formats (for environment variable validation)
+VALID_STORAGE_FORMATS = {"PVC", "MARIA"}
 
 lm_evaluation_harness_router: "APIRouter | None" = None
 try:
@@ -80,15 +69,19 @@ logging.basicConfig(
 logging.getLogger("src").setLevel(logging.DEBUG)
 logging.getLogger("__main__").setLevel(logging.DEBUG)
 
+# Migration status cache for readiness probe optimization
+# Prevents database query on every health check (typically every 10s)
+# Cache TTL: 60 seconds (once migration is complete, it stays complete)
+_migration_status_cache: dict[str, Any] = {"status": None, "timestamp": 0}
+_MIGRATION_CACHE_TTL = 60.0  # seconds
+
 # Remove noisy HTTP/2 and hypercorn internal logs
 logging.getLogger("hpack.hpack").setLevel(logging.WARNING)
 logging.getLogger("hypercorn.protocol").setLevel(logging.INFO)
 logging.getLogger("hypercorn.access").setLevel(logging.INFO)
 
 # Ensure scheduler debug logging
-scheduler_logger = logging.getLogger(
-    "trustyai_service.service.prometheus.prometheus_scheduler"
-)
+scheduler_logger = logging.getLogger("trustyai_service.service.prometheus.prometheus_scheduler")
 scheduler_logger.setLevel(logging.DEBUG)
 logger = logging.getLogger(__name__)
 
@@ -132,7 +125,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
 
 app = FastAPI(
     title="TrustyAI Service API",
-    version=__version__,
+    version="1.0.0rc0",
     description="TrustyAI Service API",
     lifespan=lifespan,
 )
@@ -182,18 +175,6 @@ app.include_router(
         "Drift Metrics: KSTest",
     ],
 )
-app.include_router(
-    drift_fouriermmd_router,
-    tags=["Drift Metrics: FourierMMD"],
-)
-app.include_router(
-    drift_approxkstest_router,
-    tags=["Drift Metrics: ApproxKSTest"],
-)
-app.include_router(
-    drift_jensenshannon_router,
-    tags=["Drift Metrics: JensenShannon"],
-)
 
 app.include_router(explainers_global_router, tags=["Explainers: Global"])
 app.include_router(explainers_local_router, tags=["Explainers: Local"])
@@ -240,13 +221,130 @@ async def metrics(_request: Request) -> Response:
     return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
 
+def _handle_migration_status(status: str) -> JSONResponse | None:
+    """Handle migration status and return appropriate readiness response.
+
+    :param status: Migration status (IN_PROGRESS, FAILED, PARTIAL, or COMPLETE)
+    :return: JSONResponse if service should be not ready, None if ready
+    """
+    if status == MIGRATION_STATUS_IN_PROGRESS:
+        return JSONResponse(
+            content={
+                "status": "not_ready",
+                "reason": "Data migration in progress",
+            },
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+        )
+    if status == MIGRATION_STATUS_FAILED:
+        return JSONResponse(
+            content={
+                "status": "not_ready",
+                "reason": "Data migration failed",
+            },
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+        )
+    if status == MIGRATION_STATUS_PARTIAL:
+        logger.warning("Service ready with partial migration - some files failed")
+        # Fall through to ready (return None)
+    # COMPLETE or PARTIAL status - service is ready
+    return None
+
+
 # Readiness probe
 @app.get("/q/health/ready")
 async def readiness_probe() -> JSONResponse:
     """Kubernetes readiness probe endpoint.
 
-    :return: JSON response indicating service is ready
+    Blocks pod readiness if DATABASE_ATTEMPT_MIGRATION is enabled and migration
+    is still in progress. This ensures the service doesn't receive traffic until
+    data migration completes.
+
+    :return: JSON response indicating service is ready (200) or not ready (503)
     """
+    # Check if migration is required
+    storage_format = os.environ.get("SERVICE_STORAGE_FORMAT", "PVC")
+
+    # Validate storage format
+    if storage_format not in VALID_STORAGE_FORMATS:
+        logger.warning(
+            "Invalid SERVICE_STORAGE_FORMAT '%s', defaulting to PVC. Valid formats: %s",
+            storage_format,
+            VALID_STORAGE_FORMATS,
+        )
+        storage_format = "PVC"
+
+    migration_enabled = os.environ.get("DATABASE_ATTEMPT_MIGRATION", "0").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+    if storage_format == "MARIA" and migration_enabled:
+        # Check cache first to avoid DB query on every health check
+        current_time = time.time()
+        cache_age = current_time - _migration_status_cache["timestamp"]
+
+        # Use cached status if:
+        # 1. Cache is fresh (< TTL), OR
+        # 2. Migration is COMPLETE (no need to check again)
+        if (
+            cache_age < _MIGRATION_CACHE_TTL
+            or _migration_status_cache["status"] == MIGRATION_STATUS_COMPLETE
+        ):
+            cached_status = _migration_status_cache["status"]
+            if cached_status is not None:
+                response = _handle_migration_status(cached_status)
+                if response is not None:
+                    return response
+                # COMPLETE or PARTIAL status - fall through to ready
+        else:
+            # Cache miss or expired - query database and update cache
+            try:
+                from trustyai_service.service.data.storage import (  # noqa: PLC0415 -- conditional import based on runtime config
+                    get_global_storage_interface,
+                )
+                from trustyai_service.service.data.storage.maria.maria import (  # noqa: PLC0415 -- conditional import
+                    MariaDBStorage,
+                )
+
+                storage = get_global_storage_interface()
+
+                # Check if storage is MariaDB (type guard)
+                if isinstance(storage, MariaDBStorage):
+                    # Query migration status from database
+                    with storage.connection_manager as (_conn, cursor):
+                        cursor.execute(
+                            "SELECT status FROM trustyai_migration_status "
+                            "WHERE migration_type IN ('PVC_TO_DB', 'LEGACY_DB') "
+                            "ORDER BY started_at DESC LIMIT 1"
+                        )
+                        result = cursor.fetchone()
+
+                        if result:
+                            migration_status = result[0]
+                            # Update cache
+                            _migration_status_cache["status"] = migration_status
+                            _migration_status_cache["timestamp"] = current_time
+
+                            response = _handle_migration_status(migration_status)
+                            if response is not None:
+                                return response
+                            # Migration complete - proceed to ready state
+
+            except Exception as e:
+                # If we can't check migration status, assume not ready
+                # This prevents traffic during migration issues
+                logger.exception("Failed to check migration status")
+                return JSONResponse(
+                    content={
+                        "status": "not_ready",
+                        "reason": f"Unable to verify migration status: {e}",
+                    },
+                    status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+                )
+
+    # No migration required or migration completed successfully
     return JSONResponse(content={"status": "ready"}, status_code=HTTPStatus.OK)
 
 

--- a/src/trustyai_service/service/data/storage/maria/maria.py
+++ b/src/trustyai_service/service/data/storage/maria/maria.py
@@ -12,7 +12,10 @@ from pathlib import Path
 import mariadb
 import numpy as np
 
-from trustyai_service.endpoints.consumer import KServeInferenceRequest, KServeInferenceResponse
+from trustyai_service.endpoints.consumer import (
+    KServeInferenceRequest,
+    KServeInferenceResponse,
+)
 from trustyai_service.service.data.modelmesh_parser import PartialPayload
 from trustyai_service.service.data.storage.exceptions import DeserializationError
 from trustyai_service.service.data.storage.maria.legacy_maria_reader import (
@@ -27,7 +30,10 @@ from trustyai_service.service.data.storage.maria.utils import (
 from trustyai_service.service.data.storage.storage_interface import StorageInterface
 from trustyai_service.service.serialization import deserialize_model, serialize_model
 from trustyai_service.service.serialization.detection import safe_gzip_decompress
-from trustyai_service.service.serialization.encoders import json_decoder_hook, json_encoder
+from trustyai_service.service.serialization.encoders import (
+    json_decoder_hook,
+    json_encoder,
+)
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())

--- a/src/trustyai_service/service/data/storage/maria/maria.py
+++ b/src/trustyai_service/service/data/storage/maria/maria.py
@@ -6,19 +6,19 @@ import asyncio
 import gzip
 import json
 import logging
+import os
+from pathlib import Path
 
 import mariadb
 import numpy as np
 
-from trustyai_service.endpoints.consumer import (
-    KServeInferenceRequest,
-    KServeInferenceResponse,
-)
+from trustyai_service.endpoints.consumer import KServeInferenceRequest, KServeInferenceResponse
 from trustyai_service.service.data.modelmesh_parser import PartialPayload
 from trustyai_service.service.data.storage.exceptions import DeserializationError
 from trustyai_service.service.data.storage.maria.legacy_maria_reader import (
     LegacyMariaDBStorageReader,
 )
+from trustyai_service.service.data.storage.maria.pvc_migration import PVCToDBMigrator
 from trustyai_service.service.data.storage.maria.utils import (
     MariaConnectionManager,
     get_clean_column_names,
@@ -27,10 +27,7 @@ from trustyai_service.service.data.storage.maria.utils import (
 from trustyai_service.service.data.storage.storage_interface import StorageInterface
 from trustyai_service.service.serialization import deserialize_model, serialize_model
 from trustyai_service.service.serialization.detection import safe_gzip_decompress
-from trustyai_service.service.serialization.encoders import (
-    json_decoder_hook,
-    json_encoder,
-)
+from trustyai_service.service.serialization.encoders import json_decoder_hook, json_encoder
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
@@ -137,11 +134,11 @@ class MariaDBStorage(StorageInterface):
             # Attempt to schedule migration to run asynchronously if event loop is available
             try:
                 loop = asyncio.get_running_loop()
-                self._migration_task = loop.create_task(self._migrate_from_legacy_db())
+                self._migration_task = loop.create_task(self._run_migration())
                 self._migration_task.add_done_callback(self._on_migration_done)
             except RuntimeError:
                 # No event loop running - run migration synchronously
-                asyncio.run(self._migrate_from_legacy_db())
+                asyncio.run(self._run_migration())
 
     @staticmethod
     def _on_migration_done(task: asyncio.Task[None]) -> None:
@@ -149,10 +146,47 @@ class MariaDBStorage(StorageInterface):
             return
         exc = task.exception()
         if exc is not None:
-            logger.exception("Legacy TrustyAI v1 migration failed.", exc_info=exc)
+            logger.exception("Migration failed.", exc_info=exc)
 
     # === MIGRATORS ================================================================================
+    async def _run_migration(self) -> None:
+        """Determine which migration to run: PVC-to-DB or legacy DB schema upgrade.
+
+        Migration priority:
+        1. PVC-to-DB migration if HDF5 files exist in PVC folder
+        2. Legacy DB schema v1->v2 migration if legacy tables exist
+        3. No migration if neither condition is met
+        """
+        # Check for PVC data first (higher priority)
+        pvc_folder = os.environ.get("STORAGE_DATA_FOLDER", "/inputs")
+        pvc_path = Path(pvc_folder)
+
+        if pvc_path.exists() and pvc_path.is_dir():
+            # Check if any HDF5 files exist
+            hdf5_files = list(pvc_path.glob("*.hdf5"))
+            if hdf5_files:
+                logger.info(
+                    "Detected %d HDF5 files in %s, starting PVC-to-DB migration",
+                    len(hdf5_files),
+                    pvc_folder,
+                )
+                await self._migrate_from_pvc()
+                return
+
+        # No PVC data found, check for legacy DB schema migration
+        logger.info("No PVC data found, checking for legacy DB schema migration")
+        await self._migrate_from_legacy_db()
+
+    async def _migrate_from_pvc(self) -> None:
+        """Execute PVC-to-DB migration using PVCToDBMigrator."""
+        migrator = PVCToDBMigrator(
+            maria_storage=self,
+            pvc_folder=os.environ.get("STORAGE_DATA_FOLDER"),
+        )
+        await migrator.migrate()
+
     async def _migrate_from_legacy_db(self) -> None:
+        """Execute legacy DB schema v1->v2 migration."""
         legacy_reader = LegacyMariaDBStorageReader(
             user=self.user,
             password=self.password,

--- a/src/trustyai_service/service/data/storage/maria/pvc_migration.py
+++ b/src/trustyai_service/service/data/storage/maria/pvc_migration.py
@@ -1,0 +1,747 @@
+"""PVC-to-MariaDB migration module for TrustyAI Service.
+
+This module handles migrating inference data from PVC (HDF5) storage to MariaDB storage.
+Migration is triggered by the DATABASE_ATTEMPT_MIGRATION environment variable and runs
+during MariaDBStorage initialization.
+
+Key Features:
+- Idempotent migration with progress tracking
+- Per-file migration status to support resumption after pod restarts
+- Comprehensive error handling and logging
+- Observable migration status via database table
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import h5py
+import numpy as np
+from prometheus_client import Counter
+
+if TYPE_CHECKING:
+    from trustyai_service.service.data.storage.maria.maria import MariaDBStorage
+
+from trustyai_service.service.serialization import deserialize_rows
+
+logger = logging.getLogger(__name__)
+
+
+# Migration status constants
+MIGRATION_TYPE_PVC_TO_DB = "PVC_TO_DB"
+MIGRATION_STATUS_IN_PROGRESS = "IN_PROGRESS"
+MIGRATION_STATUS_COMPLETE = "COMPLETE"
+MIGRATION_STATUS_PARTIAL = "PARTIAL"
+MIGRATION_STATUS_FAILED = "FAILED"
+
+# Migration configuration defaults
+DEFAULT_BATCH_SIZE = 10000  # Rows per batch to prevent OOM on large datasets
+DEFAULT_TIMEOUT_SECONDS = 300  # 5 minutes per batch write operation
+DEFAULT_PVC_FOLDER = "/inputs"  # Default PVC mount path
+
+# Log message indicating migration completion (used by test frameworks and operators)
+MIGRATION_COMPLETE_MESSAGE = "Migration complete, the PVC is now safe to remove."
+
+# Prometheus metrics for migration observability
+migration_files_total = Counter(
+    "trustyai_migration_files_total",
+    "Total number of HDF5 files discovered for migration",
+)
+migration_files_success = Counter(
+    "trustyai_migration_files_success",
+    "Number of HDF5 files successfully migrated",
+)
+migration_files_failed = Counter(
+    "trustyai_migration_files_failed",
+    "Number of HDF5 files that failed to migrate",
+)
+migration_rows_total = Counter(
+    "trustyai_migration_rows_total",
+    "Total number of data rows migrated from PVC to MariaDB",
+)
+
+
+class PVCToDBMigrator:
+    """Handles migration of data from PVC (HDF5) storage to MariaDB.
+
+    This class encapsulates all logic for:
+    - Discovering HDF5 files in the PVC mount
+    - Reading and deserializing HDF5 datasets
+    - Tracking migration progress per file
+    - Transferring data to MariaDB storage
+    - Logging migration completion for operator awareness
+
+    Design Principles:
+    - Idempotent: Safe to run multiple times, skips already-migrated files
+    - Resumable: Can resume from checkpoint after pod restart
+    - Observable: Migration status persists in database table
+    - Fail-safe: Original PVC data remains intact (read-only operations)
+    """
+
+    # SQL schema for migration tracking table
+    MIGRATION_STATUS_TABLE_SCHEMA = """
+        CREATE TABLE IF NOT EXISTS trustyai_migration_status (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            migration_type VARCHAR(50) NOT NULL,
+            status VARCHAR(20) NOT NULL,
+            started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            completed_at TIMESTAMP NULL,
+            files_processed INT DEFAULT 0,
+            total_files INT DEFAULT 0,
+            error_message TEXT NULL,
+            INDEX idx_migration_type (migration_type),
+            INDEX idx_status (status),
+            INDEX idx_migration_type_started (migration_type, started_at DESC)
+        )
+    """
+
+    # SQL schema for per-file migration tracking
+    FILE_MIGRATION_STATUS_TABLE_SCHEMA = """
+        CREATE TABLE IF NOT EXISTS trustyai_file_migration_status (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            migration_id INT NOT NULL,
+            file_name VARCHAR(512) NOT NULL,
+            dataset_name VARCHAR(255) NOT NULL,
+            rows_migrated INT DEFAULT 0,
+            completed_at TIMESTAMP NULL,
+            error_message TEXT NULL,
+            UNIQUE KEY unique_migration_file (migration_id, file_name),
+            FOREIGN KEY (migration_id) REFERENCES trustyai_migration_status(id) ON DELETE CASCADE,
+            INDEX idx_completed (completed_at)
+        )
+    """
+
+    def __init__(
+        self,
+        maria_storage: MariaDBStorage,
+        pvc_folder: str | None = None,
+        batch_size: int | None = None,
+    ) -> None:
+        """Initialize migrator with MariaDB storage instance and PVC folder path.
+
+        :param maria_storage: MariaDBStorage instance to write migrated data to
+        :param pvc_folder: Path to PVC mount containing HDF5 files
+                          (defaults to STORAGE_DATA_FOLDER env var or DEFAULT_PVC_FOLDER)
+        :param batch_size: Number of rows to process per batch
+                          (defaults to MIGRATION_BATCH_SIZE env var or DEFAULT_BATCH_SIZE)
+        """
+        self.maria_storage = maria_storage
+        self.connection_manager = maria_storage.connection_manager
+        self.pvc_folder = pvc_folder or os.environ.get(
+            "STORAGE_DATA_FOLDER", DEFAULT_PVC_FOLDER
+        )
+        self.batch_size = batch_size or int(
+            os.environ.get("MIGRATION_BATCH_SIZE", str(DEFAULT_BATCH_SIZE))
+        )
+        self._migration_id: int | None = None
+
+    def _create_migration_tables(self) -> None:
+        """Create migration status tracking tables if they don't exist."""
+        with self.connection_manager as (_conn, cursor):
+            cursor.execute(self.MIGRATION_STATUS_TABLE_SCHEMA)
+            cursor.execute(self.FILE_MIGRATION_STATUS_TABLE_SCHEMA)
+            logger.debug("Migration tracking tables created or verified")
+
+    def _check_migration_already_completed(self) -> bool:
+        """Check if a PVC-to-DB migration has already completed.
+
+        :return: True if migration completed successfully in a previous run
+        """
+        with self.connection_manager as (_conn, cursor):
+            cursor.execute(
+                "SELECT id, status FROM trustyai_migration_status "
+                "WHERE migration_type=? AND status=? "
+                "ORDER BY started_at DESC LIMIT 1",
+                (MIGRATION_TYPE_PVC_TO_DB, MIGRATION_STATUS_COMPLETE),
+            )
+            result = cursor.fetchone()
+            return result is not None
+
+    def _start_migration_tracking(self, total_files: int) -> int:
+        """Create a new migration tracking record and return its ID.
+
+        :param total_files: Total number of HDF5 files to migrate
+        :return: Migration ID for tracking this migration run
+        """
+        with self.connection_manager as (_conn, cursor):
+            cursor.execute(
+                "INSERT INTO trustyai_migration_status "
+                "(migration_type, status, files_processed, total_files) "
+                "VALUES (?, ?, 0, ?)",
+                (MIGRATION_TYPE_PVC_TO_DB, MIGRATION_STATUS_IN_PROGRESS, total_files),
+            )
+            migration_id = cursor.lastrowid
+            logger.info(
+                "Started PVC-to-DB migration tracking (ID=%d, total_files=%d)",
+                migration_id,
+                total_files,
+            )
+            return migration_id
+
+    def _update_migration_progress(self, files_processed: int) -> None:
+        """Update migration progress in tracking table.
+
+        :param files_processed: Number of files successfully migrated so far
+        """
+        if self._migration_id is None:
+            return
+
+        with self.connection_manager as (_conn, cursor):
+            cursor.execute(
+                "UPDATE trustyai_migration_status SET files_processed=? WHERE id=?",
+                (files_processed, self._migration_id),
+            )
+            logger.debug("Migration progress: %d files processed", files_processed)
+
+    def _mark_migration_complete(self) -> None:
+        """Mark the migration as successfully completed."""
+        if self._migration_id is None:
+            return
+
+        with self.connection_manager as (_conn, cursor):
+            cursor.execute(
+                "UPDATE trustyai_migration_status "
+                "SET status=?, completed_at=CURRENT_TIMESTAMP "
+                "WHERE id=?",
+                (MIGRATION_STATUS_COMPLETE, self._migration_id),
+            )
+            logger.info("Migration marked as complete (ID=%d)", self._migration_id)
+
+    def _mark_migration_partial(self, files_succeeded: int, files_failed: int) -> None:
+        """Mark the migration as partially completed with some failures.
+
+        :param files_succeeded: Number of files successfully migrated
+        :param files_failed: Number of files that failed to migrate
+        """
+        if self._migration_id is None:
+            return
+
+        error_msg = f"{files_succeeded} files succeeded, {files_failed} files failed"
+        with self.connection_manager as (_conn, cursor):
+            cursor.execute(
+                "UPDATE trustyai_migration_status "
+                "SET status=?, error_message=?, completed_at=CURRENT_TIMESTAMP "
+                "WHERE id=?",
+                (MIGRATION_STATUS_PARTIAL, error_msg, self._migration_id),
+            )
+            logger.warning(
+                "Migration marked as partial (ID=%d): %s",
+                self._migration_id,
+                error_msg,
+            )
+
+    def _mark_migration_failed(self, error_message: str) -> None:
+        """Mark the migration as failed with error details.
+
+        :param error_message: Description of the error that caused failure
+        """
+        if self._migration_id is None:
+            return
+
+        with self.connection_manager as (_conn, cursor):
+            cursor.execute(
+                "UPDATE trustyai_migration_status "
+                "SET status=?, error_message=?, completed_at=CURRENT_TIMESTAMP "
+                "WHERE id=?",
+                (MIGRATION_STATUS_FAILED, error_message, self._migration_id),
+            )
+            logger.error(
+                "Migration marked as failed (ID=%d): %s",
+                self._migration_id,
+                error_message,
+            )
+
+    def _is_file_already_migrated(self, file_name: str) -> bool:
+        """Check if a specific HDF5 file has already been migrated.
+
+        :param file_name: Name of the HDF5 file to check
+        :return: True if file was previously migrated successfully
+        """
+        if self._migration_id is None:
+            return False
+
+        with self.connection_manager as (_conn, cursor):
+            cursor.execute(
+                "SELECT id FROM trustyai_file_migration_status "
+                "WHERE migration_id=? AND file_name=? AND completed_at IS NOT NULL",
+                (self._migration_id, file_name),
+            )
+            return cursor.fetchone() is not None
+
+    def _mark_file_migrated(
+        self, file_name: str, dataset_name: str, rows_migrated: int
+    ) -> None:
+        """Mark a file as successfully migrated.
+
+        :param file_name: Name of the migrated HDF5 file
+        :param dataset_name: Name of the dataset within the file
+        :param rows_migrated: Number of rows migrated from this file
+        """
+        if self._migration_id is None:
+            return
+
+        with self.connection_manager as (_conn, cursor):
+            # Use INSERT ... ON DUPLICATE KEY UPDATE for idempotence
+            cursor.execute(
+                "INSERT INTO trustyai_file_migration_status "
+                "(migration_id, file_name, dataset_name, rows_migrated, completed_at) "
+                "VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP) "
+                "ON DUPLICATE KEY UPDATE "
+                "rows_migrated=VALUES(rows_migrated), completed_at=CURRENT_TIMESTAMP",
+                (self._migration_id, file_name, dataset_name, rows_migrated),
+            )
+            logger.debug(
+                "Marked file as migrated: %s (dataset=%s, rows=%d)",
+                file_name,
+                dataset_name,
+                rows_migrated,
+            )
+
+    def _mark_file_failed(self, file_name: str, error_message: str) -> None:
+        """Mark a file migration as failed.
+
+        :param file_name: Name of the HDF5 file that failed to migrate
+        :param error_message: Description of the error that occurred
+        """
+        if self._migration_id is None:
+            return
+
+        with self.connection_manager as (_conn, cursor):
+            cursor.execute(
+                "INSERT INTO trustyai_file_migration_status "
+                "(migration_id, file_name, dataset_name, rows_migrated, error_message) "
+                "VALUES (?, ?, '', 0, ?) "
+                "ON DUPLICATE KEY UPDATE "
+                "error_message=VALUES(error_message)",
+                (self._migration_id, file_name, error_message),
+            )
+            logger.error(
+                "Marked file as failed: %s - %s",
+                file_name,
+                error_message,
+            )
+
+    def _discover_hdf5_files(self) -> list[Path]:
+        """Discover all HDF5 files in the PVC folder.
+
+        :return: List of Path objects for HDF5 files
+        :raises FileNotFoundError: If PVC folder doesn't exist
+        """
+        pvc_path = Path(self.pvc_folder)
+
+        if not pvc_path.exists():
+            error_msg = f"PVC folder not found: {self.pvc_folder}"
+            logger.error(error_msg)
+            raise FileNotFoundError(error_msg)
+
+        if not pvc_path.is_dir():
+            error_msg = f"PVC path is not a directory: {self.pvc_folder}"
+            logger.error(error_msg)
+            raise NotADirectoryError(error_msg)
+
+        hdf5_files = list(pvc_path.glob("*.hdf5"))
+        logger.info("Discovered %d HDF5 files in %s", len(hdf5_files), self.pvc_folder)
+
+        return hdf5_files
+
+    def _validate_hdf5_structure(self, hdf5_file: Path) -> tuple[bool, str]:
+        """Validate HDF5 file has required structure before migration.
+
+        Checks that the file:
+        - Contains at least one dataset
+        - Each dataset has required 'column_names' attribute
+        - Warns if datasets are empty (allowed but logged for awareness)
+
+        Empty datasets are permitted as they may represent models with no inference
+        data yet. The warning helps operators distinguish between intentional empty
+        datasets and potential data issues.
+
+        :param hdf5_file: Path to HDF5 file to validate
+        :return: Tuple of (is_valid, error_message). error_message is empty string if valid
+        """
+        try:
+            with h5py.File(hdf5_file, "r") as h5f:
+                if len(h5f.keys()) == 0:
+                    return False, "File contains no datasets"
+
+                for dataset_name in h5f:
+                    dataset = h5f[dataset_name]
+
+                    # Check required attributes exist
+                    if "column_names" not in dataset.attrs:
+                        return (
+                            False,
+                            f"Dataset '{dataset_name}' missing 'column_names' attribute",
+                        )
+
+                    # Warn if dataset is empty (not a failure, might be intentional)
+                    if len(dataset) == 0:
+                        logger.warning(
+                            "Dataset '%s' is empty in %s - will migrate metadata only",
+                            dataset_name,
+                            hdf5_file.name,
+                        )
+
+            return True, ""  # noqa: TRY300
+
+        except Exception as e:
+            msg = f"HDF5 validation error: {e}"
+            return False, msg
+
+    async def _validate_migration(self, dataset_name: str, expected_rows: int) -> bool:
+        """Validate migrated data row count matches source.
+
+        Queries MariaDB to verify the number of rows in the migrated dataset
+        matches the expected count from the HDF5 source.
+
+        Note: Validation occurs AFTER data is written to MariaDB. If validation fails,
+        data remains in the database but migration is marked as failed. This allows
+        manual inspection and recovery rather than silent data loss.
+
+        :param dataset_name: Name of the dataset in MariaDB
+        :param expected_rows: Expected row count from HDF5 source
+        :return: True if validation passed, False otherwise
+        """
+        try:
+            with self.connection_manager as (_conn, cursor):
+                cursor.execute(
+                    "SELECT n_rows FROM trustyai_v2_table_reference WHERE dataset_name=?",
+                    (dataset_name,),
+                )
+                result = cursor.fetchone()
+
+                if not result:
+                    logger.error(
+                        "Validation FAILED: Dataset '%s' not found in MariaDB table reference",
+                        dataset_name,
+                    )
+                    return False
+
+                actual_rows = result[0]
+                if actual_rows != expected_rows:
+                    logger.error(
+                        "Validation FAILED: Dataset '%s' has %d rows in MariaDB, expected %d from HDF5",
+                        dataset_name,
+                        actual_rows,
+                        expected_rows,
+                    )
+                    return False
+
+                logger.info(
+                    "✓ Validation passed: Dataset '%s' has %d rows in MariaDB",
+                    dataset_name,
+                    expected_rows,
+                )
+                return True
+        except Exception:
+            logger.exception(
+                "Validation query failed for dataset '%s' (database schema issue?)",
+                dataset_name,
+            )
+            return False
+
+    def _read_hdf5_dataset(
+        self, hdf5_file: Path, dataset_name: str
+    ) -> tuple[np.ndarray, list[str], bool]:
+        """Read a dataset from an HDF5 file with attributes.
+
+        :param hdf5_file: Path to the HDF5 file
+        :param dataset_name: Name of the dataset within the file
+        :return: Tuple of (data array, column names, is_bytes flag)
+        :raises ValueError: If dataset doesn't exist in file
+        """
+        with h5py.File(hdf5_file, "r") as h5f:
+            if dataset_name not in h5f:
+                error_msg = (
+                    f"Dataset '{dataset_name}' not found in file {hdf5_file.name}"
+                )
+                logger.error(error_msg)
+                raise ValueError(error_msg)
+
+            dataset = h5f[dataset_name]
+
+            # Read HDF5 attributes
+            column_names = list(dataset.attrs.get("column_names", []))
+            is_bytes = dataset.attrs.get("is_bytes", False)
+
+            # Read data
+            data = dataset[:]
+
+            logger.debug(
+                "Read dataset '%s' from %s: shape=%s, is_bytes=%s, columns=%d",
+                dataset_name,
+                hdf5_file.name,
+                data.shape,
+                is_bytes,
+                len(column_names),
+            )
+
+            return data, column_names, is_bytes
+
+    async def _write_data_to_maria(
+        self,
+        dataset_name: str,
+        data: np.ndarray,
+        column_names: list[str],
+    ) -> None:
+        """Write migrated data to MariaDB storage.
+
+        :param dataset_name: Name for the dataset in MariaDB
+        :param data: Data array to write
+        :param column_names: Column names for the dataset
+        """
+        # Convert numpy array to list for MariaDB write_data
+        data_list = data.tolist() if isinstance(data, np.ndarray) else list(data)
+
+        await self.maria_storage.write_data(
+            dataset_name=dataset_name,
+            new_rows=data_list,
+            column_names=column_names,
+        )
+
+        logger.debug(
+            "Wrote %d rows to MariaDB dataset '%s'",
+            len(data_list),
+            dataset_name,
+        )
+
+    async def _write_data_to_maria_with_timeout(
+        self,
+        dataset_name: str,
+        data: np.ndarray,
+        column_names: list[str],
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        """Write migrated data to MariaDB storage with timeout protection.
+
+        :param dataset_name: Name for the dataset in MariaDB
+        :param data: Data array to write
+        :param column_names: Column names for the dataset
+        :param timeout_seconds: Timeout in seconds (default DEFAULT_TIMEOUT_SECONDS)
+        :raises TimeoutError: If write operation exceeds timeout
+        """
+        try:
+            async with asyncio.timeout(timeout_seconds):
+                await self._write_data_to_maria(dataset_name, data, column_names)
+        except TimeoutError as e:
+            error_msg = (
+                f"Database write timeout ({timeout_seconds}s) exceeded for dataset '{dataset_name}' "
+                f"({len(data)} rows)"
+            )
+            logger.exception(error_msg)
+            raise TimeoutError(error_msg) from e
+
+    async def _migrate_single_file(self, hdf5_file: Path) -> int:
+        """Migrate all datasets from a single HDF5 file to MariaDB in batches.
+
+        Validates file structure before migration and validates row counts after.
+
+        :param hdf5_file: Path to the HDF5 file to migrate
+        :return: Total number of rows migrated from this file
+        :raises ValueError: If validation fails (pre or post migration)
+        :raises Exception: Any error during migration (will be caught by caller)
+        """
+        logger.info("Migrating file: %s", hdf5_file.name)
+
+        # PRE-MIGRATION VALIDATION: Check file structure
+        is_valid, error_msg = self._validate_hdf5_structure(hdf5_file)
+        if not is_valid:
+            msg = f"HDF5 structure validation failed for {hdf5_file.name}: {error_msg}"
+            raise ValueError(msg)
+
+        total_rows = 0
+
+        with h5py.File(hdf5_file, "r") as h5f:
+            for dataset_name in h5f:
+                dataset = h5f[dataset_name]
+                dataset_rows = len(dataset)
+                column_names = list(dataset.attrs.get("column_names", []))
+                is_bytes = dataset.attrs.get("is_bytes", False)
+
+                logger.info(
+                    "  Migrating dataset '%s': %d rows (batch size: %d)",
+                    dataset_name,
+                    dataset_rows,
+                    self.batch_size,
+                )
+
+                # Migrate in batches to avoid OOM on large datasets
+                start_idx = 0
+                while start_idx < dataset_rows:
+                    end_idx = min(start_idx + self.batch_size, dataset_rows)
+
+                    # Log progress for large datasets
+                    if dataset_rows > self.batch_size:
+                        logger.info(
+                            "    Processing rows %d-%d of %d",
+                            start_idx,
+                            end_idx,
+                            dataset_rows,
+                        )
+
+                    # Read batch from HDF5
+                    batch_data = dataset[start_idx:end_idx]
+
+                    # Deserialize if data is in serialized format (JSON+gzip)
+                    if is_bytes and batch_data.dtype.type in {np.bytes_, np.void}:
+                        logger.debug(
+                            "Deserializing byte data for dataset '%s' batch %d-%d",
+                            dataset_name,
+                            start_idx,
+                            end_idx,
+                        )
+                        try:
+                            batch_data = deserialize_rows(batch_data)
+                        except Exception as deser_error:
+                            error_msg = (
+                                f"Failed to deserialize dataset '{dataset_name}' "
+                                f"batch {start_idx}-{end_idx} in file {hdf5_file.name}: {deser_error}"
+                            )
+                            logger.exception(error_msg)
+                            raise ValueError(error_msg) from deser_error
+
+                    # Write batch to MariaDB with timeout protection
+                    await self._write_data_to_maria_with_timeout(
+                        dataset_name, batch_data, column_names, timeout_seconds=300
+                    )
+
+                    start_idx += self.batch_size
+
+                # POST-MIGRATION VALIDATION: Verify row count matches
+                validation_passed = await self._validate_migration(
+                    dataset_name, dataset_rows
+                )
+                if not validation_passed:
+                    msg = (
+                        f"Post-migration validation failed for dataset '{dataset_name}' "
+                        f"in file {hdf5_file.name}"
+                    )
+                    raise ValueError(msg)
+
+                total_rows += dataset_rows
+                logger.info(
+                    "  Completed dataset '%s': %d rows migrated",
+                    dataset_name,
+                    dataset_rows,
+                )
+
+        return total_rows
+
+    async def migrate(self) -> None:
+        """Execute the full PVC-to-DB migration process.
+
+        This is the main entry point for migration. It handles:
+        1. Checking if migration already completed
+        2. Discovering HDF5 files
+        3. Creating migration tracking tables
+        4. Migrating each file with progress tracking
+        5. Logging completion message for operator
+
+        Migration is idempotent and resumable - safe to call multiple times.
+
+        :raises FileNotFoundError: If PVC folder doesn't exist
+        :raises Exception: Any unexpected error during migration
+        """
+        # Step 1: Create migration tracking tables
+        self._create_migration_tables()
+
+        # Step 2: Check if migration already completed
+        if self._check_migration_already_completed():
+            logger.info("PVC-to-DB migration already completed in a previous run")
+            logger.info(MIGRATION_COMPLETE_MESSAGE)
+            return
+
+        # Step 3: Discover HDF5 files
+        try:
+            hdf5_files = self._discover_hdf5_files()
+        except (FileNotFoundError, NotADirectoryError) as e:
+            logger.warning("PVC folder not accessible, skipping migration: %s", e)
+            # Not an error - PVC might not be mounted during initial DB setup
+            return
+
+        if not hdf5_files:
+            logger.info(
+                "No HDF5 files found in %s, nothing to migrate", self.pvc_folder
+            )
+            logger.info(MIGRATION_COMPLETE_MESSAGE)
+            return
+
+        # Step 4: Start migration tracking
+        migration_files_total.inc(len(hdf5_files))
+        self._migration_id = self._start_migration_tracking(len(hdf5_files))
+        files_processed = 0
+        files_failed = 0
+        total_rows_migrated = 0
+
+        try:
+            # Step 5: Migrate each file
+            for hdf5_file in hdf5_files:
+                # Skip if already migrated (idempotence)
+                if self._is_file_already_migrated(hdf5_file.name):
+                    logger.info("Skipping already-migrated file: %s", hdf5_file.name)
+                    files_processed += 1
+                    continue
+
+                # Migrate the file
+                try:
+                    rows_migrated = await self._migrate_single_file(hdf5_file)
+                    total_rows_migrated += rows_migrated
+
+                    # Mark file as successfully migrated
+                    # Extract dataset name from filename (remove _trustyai.hdf5 suffix)
+                    dataset_name = hdf5_file.stem.replace("_trustyai", "")
+                    self._mark_file_migrated(
+                        hdf5_file.name, dataset_name, rows_migrated
+                    )
+
+                    files_processed += 1
+                    self._update_migration_progress(files_processed)
+
+                    # Update Prometheus metrics
+                    migration_files_success.inc()
+                    migration_rows_total.inc(rows_migrated)
+
+                except Exception as file_error:
+                    logger.exception(
+                        "Failed to migrate file %s",
+                        hdf5_file.name,
+                    )
+                    # Mark file as failed
+                    self._mark_file_failed(hdf5_file.name, str(file_error))
+                    files_failed += 1
+                    migration_files_failed.inc()
+                    # Continue with next file instead of aborting entire migration
+                    # This allows partial recovery if only some files are corrupted
+                    continue
+
+            # Step 6: Mark migration complete or partial based on failures
+            if files_failed == 0:
+                self._mark_migration_complete()
+                logger.info(
+                    "Successfully migrated %d files (%d total rows) from PVC to MariaDB",
+                    files_processed,
+                    total_rows_migrated,
+                )
+                logger.info(MIGRATION_COMPLETE_MESSAGE)
+            else:
+                self._mark_migration_partial(files_processed, files_failed)
+                logger.warning(
+                    "Partial migration: %d files succeeded, %d files failed (%d total rows migrated)",
+                    files_processed,
+                    files_failed,
+                    total_rows_migrated,
+                )
+                logger.warning(
+                    "Migration partially complete. Review failed files before removing PVC."
+                )
+
+        except Exception as migration_error:
+            # Mark migration as failed
+            error_msg = f"Migration failed: {migration_error}"
+            self._mark_migration_failed(error_msg)
+            logger.exception("PVC-to-DB migration failed")
+            raise

--- a/src/trustyai_service/service/data/storage/maria/pvc_migration.py
+++ b/src/trustyai_service/service/data/storage/maria/pvc_migration.py
@@ -47,8 +47,9 @@ DEFAULT_PVC_FOLDER = "/inputs"  # Default PVC mount path
 MIGRATION_COMPLETE_MESSAGE = "Migration complete, the PVC is now safe to remove."
 
 # Prometheus metrics for migration observability
-migration_files_total = Counter(
-    "trustyai_migration_files_total",
+# Note: Prometheus automatically adds _total suffix to Counter metric names
+migration_files = Counter(
+    "trustyai_migration_files",
     "Total number of HDF5 files discovered for migration",
 )
 migration_files_success = Counter(
@@ -59,8 +60,8 @@ migration_files_failed = Counter(
     "trustyai_migration_files_failed",
     "Number of HDF5 files that failed to migrate",
 )
-migration_rows_total = Counter(
-    "trustyai_migration_rows_total",
+migration_rows = Counter(
+    "trustyai_migration_rows",
     "Total number of data rows migrated from PVC to MariaDB",
 )
 
@@ -134,9 +135,19 @@ class PVCToDBMigrator:
         self.pvc_folder = pvc_folder or os.environ.get(
             "STORAGE_DATA_FOLDER", DEFAULT_PVC_FOLDER
         )
-        self.batch_size = batch_size or int(
+
+        # Validate and set batch size
+        batch_size_value = batch_size or int(
             os.environ.get("MIGRATION_BATCH_SIZE", str(DEFAULT_BATCH_SIZE))
         )
+        if batch_size_value <= 0:
+            msg = (
+                f"MIGRATION_BATCH_SIZE must be > 0, got {batch_size_value}. "
+                f"Check MIGRATION_BATCH_SIZE environment variable or batch_size parameter."
+            )
+            raise ValueError(msg)
+        self.batch_size = batch_size_value
+
         self._migration_id: int | None = None
 
     def _create_migration_tables(self) -> None:
@@ -162,12 +173,33 @@ class PVCToDBMigrator:
             return result is not None
 
     def _start_migration_tracking(self, total_files: int) -> int:
-        """Create a new migration tracking record and return its ID.
+        """Create or resume a migration tracking record and return its ID.
+
+        Checks for an existing IN_PROGRESS migration and resumes it if found,
+        otherwise creates a new migration tracking record.
 
         :param total_files: Total number of HDF5 files to migrate
         :return: Migration ID for tracking this migration run
         """
         with self.connection_manager as (_conn, cursor):
+            # Check for existing IN_PROGRESS migration to resume
+            cursor.execute(
+                "SELECT id, total_files FROM trustyai_migration_status "
+                "WHERE migration_type=? AND status=? "
+                "ORDER BY started_at DESC LIMIT 1",
+                (MIGRATION_TYPE_PVC_TO_DB, MIGRATION_STATUS_IN_PROGRESS),
+            )
+            result = cursor.fetchone()
+
+            if result:
+                migration_id = result[0]
+                logger.info(
+                    "Resuming existing migration ID=%s (was in progress)",
+                    migration_id,
+                )
+                return migration_id
+
+            # No existing IN_PROGRESS migration - create new one
             cursor.execute(
                 "INSERT INTO trustyai_migration_status "
                 "(migration_type, status, files_processed, total_files) "
@@ -494,18 +526,18 @@ class PVCToDBMigrator:
         :param data: Data array to write
         :param column_names: Column names for the dataset
         """
-        # Convert numpy array to list for MariaDB write_data
-        data_list = data.tolist() if isinstance(data, np.ndarray) else list(data)
+        # Ensure data is ndarray (MariaDB write_data expects ndarray, not list)
+        data_array = data if isinstance(data, np.ndarray) else np.array(data)
 
         await self.maria_storage.write_data(
             dataset_name=dataset_name,
-            new_rows=data_list,
+            new_rows=data_array,
             column_names=column_names,
         )
 
         logger.debug(
             "Wrote %d rows to MariaDB dataset '%s'",
-            len(data_list),
+            len(data_array),
             dataset_name,
         )
 
@@ -569,58 +601,67 @@ class PVCToDBMigrator:
                     self.batch_size,
                 )
 
-                # Migrate in batches to avoid OOM on large datasets
-                start_idx = 0
-                while start_idx < dataset_rows:
-                    end_idx = min(start_idx + self.batch_size, dataset_rows)
+                # Handle empty datasets (0 rows) - skip migration and validation
+                if dataset_rows == 0:
+                    logger.info(
+                        "Dataset '%s' is empty (0 rows) - skipping migration",
+                        dataset_name,
+                    )
+                    # No data to migrate, validation will pass trivially (0 == 0)
+                    # Continue to next dataset
+                else:
+                    # Migrate in batches to avoid OOM on large datasets
+                    start_idx = 0
+                    while start_idx < dataset_rows:
+                        end_idx = min(start_idx + self.batch_size, dataset_rows)
 
-                    # Log progress for large datasets
-                    if dataset_rows > self.batch_size:
-                        logger.info(
-                            "    Processing rows %d-%d of %d",
-                            start_idx,
-                            end_idx,
-                            dataset_rows,
-                        )
-
-                    # Read batch from HDF5
-                    batch_data = dataset[start_idx:end_idx]
-
-                    # Deserialize if data is in serialized format (JSON+gzip)
-                    if is_bytes and batch_data.dtype.type in {np.bytes_, np.void}:
-                        logger.debug(
-                            "Deserializing byte data for dataset '%s' batch %d-%d",
-                            dataset_name,
-                            start_idx,
-                            end_idx,
-                        )
-                        try:
-                            batch_data = deserialize_rows(batch_data)
-                        except Exception as deser_error:
-                            error_msg = (
-                                f"Failed to deserialize dataset '{dataset_name}' "
-                                f"batch {start_idx}-{end_idx} in file {hdf5_file.name}: {deser_error}"
+                        # Log progress for large datasets
+                        if dataset_rows > self.batch_size:
+                            logger.info(
+                                "    Processing rows %d-%d of %d",
+                                start_idx,
+                                end_idx,
+                                dataset_rows,
                             )
-                            logger.exception(error_msg)
-                            raise ValueError(error_msg) from deser_error
 
-                    # Write batch to MariaDB with timeout protection
-                    await self._write_data_to_maria_with_timeout(
-                        dataset_name, batch_data, column_names, timeout_seconds=300
+                        # Read batch from HDF5
+                        batch_data = dataset[start_idx:end_idx]
+
+                        # Deserialize if data is in serialized format (JSON+gzip)
+                        if is_bytes and batch_data.dtype.type in {np.bytes_, np.void}:
+                            logger.debug(
+                                "Deserializing byte data for dataset '%s' batch %d-%d",
+                                dataset_name,
+                                start_idx,
+                                end_idx,
+                            )
+                            try:
+                                batch_data = deserialize_rows(batch_data)
+                            except Exception as deser_error:
+                                error_msg = (
+                                    f"Failed to deserialize dataset '{dataset_name}' "
+                                    f"batch {start_idx}-{end_idx} in file {hdf5_file.name}: {deser_error}"
+                                )
+                                logger.exception(error_msg)
+                                raise ValueError(error_msg) from deser_error
+
+                        # Write batch to MariaDB with timeout protection
+                        await self._write_data_to_maria_with_timeout(
+                            dataset_name, batch_data, column_names, timeout_seconds=300
+                        )
+
+                        start_idx += self.batch_size
+
+                    # POST-MIGRATION VALIDATION: Verify row count matches
+                    validation_passed = await self._validate_migration(
+                        dataset_name, dataset_rows
                     )
-
-                    start_idx += self.batch_size
-
-                # POST-MIGRATION VALIDATION: Verify row count matches
-                validation_passed = await self._validate_migration(
-                    dataset_name, dataset_rows
-                )
-                if not validation_passed:
-                    msg = (
-                        f"Post-migration validation failed for dataset '{dataset_name}' "
-                        f"in file {hdf5_file.name}"
-                    )
-                    raise ValueError(msg)
+                    if not validation_passed:
+                        msg = (
+                            f"Post-migration validation failed for dataset '{dataset_name}' "
+                            f"in file {hdf5_file.name}"
+                        )
+                        raise ValueError(msg)
 
                 total_rows += dataset_rows
                 logger.info(
@@ -671,7 +712,7 @@ class PVCToDBMigrator:
             return
 
         # Step 4: Start migration tracking
-        migration_files_total.inc(len(hdf5_files))
+        migration_files.inc(len(hdf5_files))
         self._migration_id = self._start_migration_tracking(len(hdf5_files))
         files_processed = 0
         files_failed = 0
@@ -703,7 +744,7 @@ class PVCToDBMigrator:
 
                     # Update Prometheus metrics
                     migration_files_success.inc()
-                    migration_rows_total.inc(rows_migrated)
+                    migration_rows.inc(rows_migrated)
 
                 except Exception as file_error:
                     logger.exception(

--- a/tests/service/data/storage/maria/__init__.py
+++ b/tests/service/data/storage/maria/__init__.py
@@ -1,0 +1,1 @@
+"""MariaDB storage tests."""

--- a/tests/service/data/storage/maria/test_pvc_migration.py
+++ b/tests/service/data/storage/maria/test_pvc_migration.py
@@ -226,6 +226,7 @@ class TestMigrationStatusTracking:
     def test_start_migration_tracking(self, mock_maria_storage):
         """Test starting migration tracking record."""
         mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_cursor.fetchone.return_value = None  # No existing IN_PROGRESS migration
         mock_cursor.lastrowid = 42
         mock_maria_storage.connection_manager = mock_conn_mgr
 
@@ -233,12 +234,16 @@ class TestMigrationStatusTracking:
         migration_id = migrator._start_migration_tracking(total_files=10)
 
         assert migration_id == 42
-        mock_cursor.execute.assert_called_once()
+        assert mock_cursor.execute.call_count == 2  # SELECT + INSERT
 
-        # Verify INSERT statement
-        call_args = mock_cursor.execute.call_args[0]
-        assert "INSERT INTO trustyai_migration_status" in call_args[0]
-        assert call_args[1] == (
+        # Verify SELECT statement (first call)
+        first_call = mock_cursor.execute.call_args_list[0][0]
+        assert "SELECT id, total_files FROM trustyai_migration_status" in first_call[0]
+
+        # Verify INSERT statement (second call)
+        second_call = mock_cursor.execute.call_args_list[1][0]
+        assert "INSERT INTO trustyai_migration_status" in second_call[0]
+        assert second_call[1] == (
             MIGRATION_TYPE_PVC_TO_DB,
             MIGRATION_STATUS_IN_PROGRESS,
             10,
@@ -429,7 +434,7 @@ class TestDataWriting:
         call_kwargs = mock_maria_storage.write_data.call_args.kwargs
         assert call_kwargs["dataset_name"] == "test_dataset"
         assert call_kwargs["column_names"] == column_names
-        assert call_kwargs["new_rows"] == [[1, 2, 3], [4, 5, 6]]
+        np.testing.assert_array_equal(call_kwargs["new_rows"], [[1, 2, 3], [4, 5, 6]])
 
 
 class TestSingleFileMigration:
@@ -545,12 +550,29 @@ class TestErrorHandling:
     ):
         """Test migration continues when individual file fails."""
         mock_conn_mgr, mock_cursor = mock_connection_manager()
-        mock_cursor.fetchone = MagicMock(
-            side_effect=[
-                None,  # migration not completed
-                None,  # first file not migrated
-            ]
-        )
+
+        # Use semantic mock instead of brittle side_effect list
+        def mock_fetchone(*args, **kwargs):  # noqa: ARG001
+            if mock_cursor.execute.call_args:
+                call_args = mock_cursor.execute.call_args[0]
+                # Check for existing IN_PROGRESS migration (resume logic)
+                if (
+                    "SELECT id, total_files FROM trustyai_migration_status"
+                    in call_args[0]
+                ):
+                    return  # No existing migration to resume
+                # Check if migration already completed
+                if (
+                    "SELECT id FROM trustyai_migration_status" in call_args[0]
+                    and "status=?" in call_args[0]
+                ):
+                    return  # Migration not completed yet
+                # Check if file already migrated
+                if "SELECT id FROM trustyai_file_migration_status" in call_args[0]:
+                    return  # File not yet migrated
+            return  # Default for other queries
+
+        mock_cursor.fetchone = MagicMock(side_effect=mock_fetchone)
         mock_cursor.lastrowid = 1
         mock_maria_storage.connection_manager = mock_conn_mgr
 
@@ -624,12 +646,29 @@ class TestErrorHandling:
     ):
         """Test migration skips files that were already migrated."""
         mock_conn_mgr, mock_cursor = mock_connection_manager()
-        mock_cursor.fetchone = MagicMock(
-            side_effect=[
-                None,  # migration not complete
-                (1,),  # file already migrated (returns count)
-            ]
-        )
+
+        # Use semantic mock instead of brittle side_effect list
+        def mock_fetchone(*args, **kwargs):  # noqa: ARG001
+            if mock_cursor.execute.call_args:
+                call_args = mock_cursor.execute.call_args[0]
+                # Check for existing IN_PROGRESS migration (resume logic)
+                if (
+                    "SELECT id, total_files FROM trustyai_migration_status"
+                    in call_args[0]
+                ):
+                    return None  # No existing migration to resume
+                # Check if migration already completed
+                if (
+                    "SELECT id FROM trustyai_migration_status" in call_args[0]
+                    and "status=?" in call_args[0]
+                ):
+                    return None  # Migration not completed yet
+                # Check if file already migrated - return ID to indicate it was migrated
+                if "SELECT id FROM trustyai_file_migration_status" in call_args[0]:
+                    return (1,)  # File already migrated, skip it
+            return None  # Default for other queries
+
+        mock_cursor.fetchone = MagicMock(side_effect=mock_fetchone)
         mock_cursor.lastrowid = 1
         mock_maria_storage.connection_manager = mock_conn_mgr
 

--- a/tests/service/data/storage/maria/test_pvc_migration.py
+++ b/tests/service/data/storage/maria/test_pvc_migration.py
@@ -1,0 +1,731 @@
+"""Unit tests for PVC-to-MariaDB migration module."""
+
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import h5py
+import numpy as np
+import pytest
+
+from trustyai_service.service.data.storage.maria.pvc_migration import (
+    DEFAULT_BATCH_SIZE,
+    MIGRATION_STATUS_COMPLETE,
+    MIGRATION_STATUS_FAILED,
+    MIGRATION_STATUS_IN_PROGRESS,
+    MIGRATION_TYPE_PVC_TO_DB,
+    PVCToDBMigrator,
+)
+
+
+@pytest.fixture
+def mock_maria_storage() -> MagicMock:
+    """Create a mock MariaDBStorage instance."""
+    storage = MagicMock()
+
+    # Track total rows written per dataset for validation
+    rows_written: dict[str, int] = {}
+
+    # Mock write_data to track rows
+    async def mock_write_data(
+        dataset_name: str,
+        new_rows: np.ndarray,
+        column_names: list[str],  # noqa: ARG001
+    ) -> None:
+        if dataset_name not in rows_written:
+            rows_written[dataset_name] = 0
+        rows_written[dataset_name] += len(new_rows)
+
+    storage.write_data = AsyncMock(side_effect=mock_write_data)
+
+    # Setup connection manager with proper context manager protocol
+    # that returns (conn, cursor) tuple
+    cursor = MagicMock()
+
+    # Mock fetchone to return the tracked row count for validation queries
+    def mock_fetchone() -> tuple[int] | None:
+        # Extract dataset name from the last execute() call for validation
+        if cursor.execute.call_args:
+            call_args = cursor.execute.call_args[0]
+            # Check if this is a validation query (contains trustyai_v2_table_reference)
+            if (
+                len(call_args) > 0
+                and "trustyai_v2_table_reference" in call_args[0]
+                and len(call_args) > 1
+                and isinstance(call_args[1], tuple)
+            ):
+                dataset_name = call_args[1][0]
+                return (rows_written.get(dataset_name, 0),)
+        # For other queries (migration status, file status), return None
+        return None
+
+    cursor.fetchone = MagicMock(side_effect=mock_fetchone)
+    cursor.fetchall = MagicMock(return_value=[])
+    cursor.lastrowid = 1
+
+    conn_mgr = MagicMock()
+    conn_mgr.__enter__ = MagicMock(return_value=(MagicMock(), cursor))
+    conn_mgr.__exit__ = MagicMock(return_value=None)
+
+    storage.connection_manager = conn_mgr
+    return storage
+
+
+def mock_connection_manager() -> tuple[MagicMock, MagicMock]:
+    """Create a mock MariaConnectionManager with context manager support.
+
+    This is a helper function (not a fixture) that returns a tuple of
+    (manager, cursor) for setting up connection manager mocks in tests.
+    """
+    manager = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone = MagicMock(return_value=None)
+    cursor.fetchall = MagicMock(return_value=[])
+    cursor.lastrowid = 1
+
+    # Setup context manager protocol
+    conn_context = MagicMock()
+    conn_context.__enter__ = MagicMock(return_value=(MagicMock(), cursor))
+    conn_context.__exit__ = MagicMock(return_value=None)
+    manager.__enter__ = MagicMock(return_value=conn_context.__enter__())
+    manager.__exit__ = MagicMock(return_value=None)
+
+    return manager, cursor
+
+
+@pytest.fixture
+def temp_pvc_dir() -> Generator[Path, None, None]:
+    """Create a temporary directory for PVC HDF5 files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.fixture
+def sample_hdf5_file(temp_pvc_dir: Path) -> Path:
+    """Create a sample HDF5 file with test data."""
+    file_path = temp_pvc_dir / "test_model_inputs_trustyai.hdf5"
+
+    with h5py.File(file_path, "w") as h5f:
+        # Create dataset with numeric data
+        data = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        dataset = h5f.create_dataset("test_model_inputs", data=data)
+
+        # Add attributes
+        dataset.attrs["column_names"] = ["feature_1", "feature_2", "feature_3"]
+        dataset.attrs["is_bytes"] = False
+
+    return file_path
+
+
+class TestPVCToDBMigratorInit:
+    """Test PVCToDBMigrator initialization."""
+
+    def test_init_with_explicit_pvc_folder(self, mock_maria_storage):
+        """Test initialization with explicit PVC folder path."""
+        migrator = PVCToDBMigrator(
+            maria_storage=mock_maria_storage, pvc_folder="/custom/path"
+        )
+
+        assert migrator.maria_storage == mock_maria_storage
+        assert migrator.pvc_folder == "/custom/path"
+        assert migrator._migration_id is None
+
+    def test_init_with_env_var_pvc_folder(self, mock_maria_storage, monkeypatch):
+        """Test initialization using STORAGE_DATA_FOLDER env var."""
+        monkeypatch.setenv("STORAGE_DATA_FOLDER", "/env/path")
+
+        migrator = PVCToDBMigrator(maria_storage=mock_maria_storage)
+
+        assert migrator.pvc_folder == "/env/path"
+
+    def test_init_with_default_pvc_folder(self, mock_maria_storage, monkeypatch):
+        """Test initialization with default PVC folder."""
+        monkeypatch.delenv("STORAGE_DATA_FOLDER", raising=False)
+
+        migrator = PVCToDBMigrator(maria_storage=mock_maria_storage)
+
+        assert migrator.pvc_folder == "/inputs"
+
+    def test_init_with_explicit_batch_size(self, mock_maria_storage):
+        """Test initialization with explicit batch size."""
+        migrator = PVCToDBMigrator(maria_storage=mock_maria_storage, batch_size=5000)
+
+        assert migrator.batch_size == 5000
+
+    def test_init_with_env_var_batch_size(self, mock_maria_storage, monkeypatch):
+        """Test initialization using MIGRATION_BATCH_SIZE env var."""
+        monkeypatch.setenv("MIGRATION_BATCH_SIZE", "500")
+
+        migrator = PVCToDBMigrator(maria_storage=mock_maria_storage)
+
+        assert migrator.batch_size == 500
+
+    def test_init_with_default_batch_size(self, mock_maria_storage, monkeypatch):
+        """Test initialization with default batch size."""
+        monkeypatch.delenv("MIGRATION_BATCH_SIZE", raising=False)
+
+        migrator = PVCToDBMigrator(maria_storage=mock_maria_storage)
+
+        assert migrator.batch_size == DEFAULT_BATCH_SIZE
+
+
+class TestMigrationTableCreation:
+    """Test migration tracking table creation."""
+
+    def test_create_migration_tables(self, mock_maria_storage):
+        """Test that migration tables are created with correct schema."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        migrator._create_migration_tables()
+
+        # Verify both CREATE TABLE statements were executed
+        assert mock_cursor.execute.call_count == 2
+
+        # Check migration_status table creation
+        first_call = mock_cursor.execute.call_args_list[0][0][0]
+        assert "trustyai_migration_status" in first_call
+        assert "migration_type VARCHAR(50)" in first_call
+        assert "status VARCHAR(20)" in first_call
+
+        # Check file_migration_status table creation
+        second_call = mock_cursor.execute.call_args_list[1][0][0]
+        assert "trustyai_file_migration_status" in second_call
+        assert "file_name VARCHAR(512)" in second_call
+        assert "FOREIGN KEY (migration_id)" in second_call
+
+
+class TestMigrationStatusTracking:
+    """Test migration status tracking operations."""
+
+    def test_check_migration_not_completed(self, mock_maria_storage):
+        """Test checking when migration has not completed."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_cursor.fetchone = MagicMock(return_value=None)
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        result = migrator._check_migration_already_completed()
+
+        assert result is False
+        mock_cursor.execute.assert_called_once()
+
+    def test_check_migration_already_completed(self, mock_maria_storage):
+        """Test checking when migration has completed."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_cursor.fetchone = MagicMock(return_value=(1, MIGRATION_STATUS_COMPLETE))
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        result = migrator._check_migration_already_completed()
+
+        assert result is True
+
+    def test_start_migration_tracking(self, mock_maria_storage):
+        """Test starting migration tracking record."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_cursor.lastrowid = 42
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        migration_id = migrator._start_migration_tracking(total_files=10)
+
+        assert migration_id == 42
+        mock_cursor.execute.assert_called_once()
+
+        # Verify INSERT statement
+        call_args = mock_cursor.execute.call_args[0]
+        assert "INSERT INTO trustyai_migration_status" in call_args[0]
+        assert call_args[1] == (
+            MIGRATION_TYPE_PVC_TO_DB,
+            MIGRATION_STATUS_IN_PROGRESS,
+            10,
+        )
+
+    def test_update_migration_progress(self, mock_maria_storage):
+        """Test updating migration progress."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        migrator._migration_id = 42
+        migrator._update_migration_progress(files_processed=5)
+
+        # Verify UPDATE statement
+        call_args = mock_cursor.execute.call_args[0]
+        assert "UPDATE trustyai_migration_status" in call_args[0]
+        assert "SET files_processed=?" in call_args[0]
+        assert call_args[1] == (5, 42)
+
+    def test_mark_migration_complete(self, mock_maria_storage):
+        """Test marking migration as complete."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        migrator._migration_id = 42
+        migrator._mark_migration_complete()
+
+        # Verify UPDATE statement
+        call_args = mock_cursor.execute.call_args[0]
+        assert "UPDATE trustyai_migration_status" in call_args[0]
+        assert call_args[1] == (MIGRATION_STATUS_COMPLETE, 42)
+
+    def test_mark_migration_failed(self, mock_maria_storage):
+        """Test marking migration as failed."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        migrator._migration_id = 42
+        migrator._mark_migration_failed("Test error message")
+
+        # Verify UPDATE statement
+        call_args = mock_cursor.execute.call_args[0]
+        assert "UPDATE trustyai_migration_status" in call_args[0]
+        assert call_args[1] == (MIGRATION_STATUS_FAILED, "Test error message", 42)
+
+
+class TestFileTracking:
+    """Test per-file migration tracking."""
+
+    def test_is_file_not_migrated(self, mock_maria_storage):
+        """Test checking when file has not been migrated."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_cursor.fetchone = MagicMock(return_value=None)
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        migrator._migration_id = 42
+        result = migrator._is_file_already_migrated("test.hdf5")
+
+        assert result is False
+
+    def test_is_file_already_migrated(self, mock_maria_storage):
+        """Test checking when file has been migrated."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_cursor.fetchone = MagicMock(return_value=(1,))
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        migrator._migration_id = 42
+        result = migrator._is_file_already_migrated("test.hdf5")
+
+        assert result is True
+
+    def test_mark_file_migrated(self, mock_maria_storage):
+        """Test marking a file as migrated."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        migrator._migration_id = 42
+        migrator._mark_file_migrated("test.hdf5", "test_dataset", rows_migrated=100)
+
+        # Verify INSERT statement with ON DUPLICATE KEY UPDATE
+        call_args = mock_cursor.execute.call_args[0]
+        assert "INSERT INTO trustyai_file_migration_status" in call_args[0]
+        assert "ON DUPLICATE KEY UPDATE" in call_args[0]
+        assert call_args[1] == (42, "test.hdf5", "test_dataset", 100)
+
+
+class TestHDF5Discovery:
+    """Test HDF5 file discovery."""
+
+    def test_discover_hdf5_files_success(
+        self, mock_maria_storage, temp_pvc_dir, sample_hdf5_file
+    ):
+        """Test successful discovery of HDF5 files."""
+        # Create additional HDF5 files
+        (temp_pvc_dir / "model2_outputs_trustyai.hdf5").touch()
+        (temp_pvc_dir / "model3_metadata_trustyai.hdf5").touch()
+        (temp_pvc_dir / "not_hdf5.txt").touch()  # Should be ignored
+
+        migrator = PVCToDBMigrator(mock_maria_storage, pvc_folder=str(temp_pvc_dir))
+        hdf5_files = migrator._discover_hdf5_files()
+
+        assert len(hdf5_files) == 3
+        assert all(f.suffix == ".hdf5" for f in hdf5_files)
+
+    def test_discover_hdf5_files_folder_not_found(self, mock_maria_storage):
+        """Test discovery when PVC folder doesn't exist."""
+        migrator = PVCToDBMigrator(mock_maria_storage, pvc_folder="/nonexistent/path")
+
+        with pytest.raises(FileNotFoundError, match="PVC folder not found"):
+            migrator._discover_hdf5_files()
+
+    def test_discover_hdf5_files_empty_directory(
+        self, mock_maria_storage, temp_pvc_dir
+    ):
+        """Test discovery when no HDF5 files exist."""
+        migrator = PVCToDBMigrator(mock_maria_storage, pvc_folder=str(temp_pvc_dir))
+        hdf5_files = migrator._discover_hdf5_files()
+
+        assert len(hdf5_files) == 0
+
+
+class TestHDF5Reading:
+    """Test reading data from HDF5 files."""
+
+    def test_read_hdf5_dataset_numeric_data(self, mock_maria_storage, sample_hdf5_file):
+        """Test reading numeric data from HDF5 dataset."""
+        migrator = PVCToDBMigrator(mock_maria_storage)
+
+        data, column_names, is_bytes = migrator._read_hdf5_dataset(
+            sample_hdf5_file, "test_model_inputs"
+        )
+
+        assert data.shape == (2, 3)
+        assert column_names == ["feature_1", "feature_2", "feature_3"]
+        assert is_bytes is False or is_bytes == np.False_
+        np.testing.assert_array_equal(data, [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+    def test_read_hdf5_dataset_not_found(self, mock_maria_storage, sample_hdf5_file):
+        """Test reading nonexistent dataset raises error."""
+        migrator = PVCToDBMigrator(mock_maria_storage)
+
+        with pytest.raises(ValueError, match=r"Dataset .* not found"):
+            migrator._read_hdf5_dataset(sample_hdf5_file, "nonexistent_dataset")
+
+    def test_read_hdf5_dataset_with_serialized_data(
+        self, mock_maria_storage, temp_pvc_dir
+    ):
+        """Test reading serialized (bytes) data from HDF5 dataset."""
+        # Create HDF5 file with serialized data
+        file_path = temp_pvc_dir / "serialized_trustyai.hdf5"
+        with h5py.File(file_path, "w") as h5f:
+            # Create void type data (simulating serialized rows)
+            void_data = np.array([b"serialized1", b"serialized2"], dtype="V12")
+            dataset = h5f.create_dataset("test_dataset", data=void_data)
+            dataset.attrs["column_names"] = ["mixed_col"]
+            dataset.attrs["is_bytes"] = True
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        _data, column_names, is_bytes = migrator._read_hdf5_dataset(
+            file_path, "test_dataset"
+        )
+
+        assert is_bytes is True or is_bytes == np.True_
+        assert column_names == ["mixed_col"]
+
+
+class TestDataWriting:
+    """Test writing data to MariaDB."""
+
+    @pytest.mark.asyncio
+    async def test_write_data_to_maria(self, mock_maria_storage):
+        """Test writing migrated data to MariaDB storage."""
+        migrator = PVCToDBMigrator(mock_maria_storage)
+
+        data = np.array([[1, 2, 3], [4, 5, 6]])
+        column_names = ["col1", "col2", "col3"]
+
+        await migrator._write_data_to_maria("test_dataset", data, column_names)
+
+        # Verify write_data was called with correct arguments
+        mock_maria_storage.write_data.assert_awaited_once()
+        call_kwargs = mock_maria_storage.write_data.call_args.kwargs
+        assert call_kwargs["dataset_name"] == "test_dataset"
+        assert call_kwargs["column_names"] == column_names
+        assert call_kwargs["new_rows"] == [[1, 2, 3], [4, 5, 6]]
+
+
+class TestSingleFileMigration:
+    """Test migrating a single HDF5 file."""
+
+    @pytest.mark.asyncio
+    async def test_migrate_single_file_success(
+        self, mock_maria_storage, sample_hdf5_file
+    ):
+        """Test successful migration of a single HDF5 file."""
+        migrator = PVCToDBMigrator(mock_maria_storage)
+
+        rows_migrated = await migrator._migrate_single_file(sample_hdf5_file)
+
+        assert rows_migrated == 2  # 2 rows in sample file
+        mock_maria_storage.write_data.assert_awaited_once()
+
+
+class TestFullMigration:
+    """Test full migration workflow."""
+
+    @pytest.mark.asyncio
+    async def test_migrate_already_completed(self, mock_maria_storage):
+        """Test migration skips when already completed."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_cursor.fetchone = MagicMock(return_value=(1, MIGRATION_STATUS_COMPLETE))
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+
+        with patch.object(migrator, "_discover_hdf5_files") as mock_discover:
+            await migrator.migrate()
+
+            # Should not call discover if already completed
+            mock_discover.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_migrate_no_hdf5_files(self, mock_maria_storage, temp_pvc_dir):
+        """Test migration with no HDF5 files."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_cursor.fetchone = MagicMock(return_value=None)
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage, pvc_folder=str(temp_pvc_dir))
+
+        await migrator.migrate()
+
+        # Should complete without error and log completion message
+
+    @pytest.mark.asyncio
+    async def test_migrate_pvc_folder_not_found(self, mock_maria_storage):
+        """Test migration when PVC folder doesn't exist."""
+        mock_conn_mgr, _mock_cursor = mock_connection_manager()
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage, pvc_folder="/nonexistent")
+
+        # Should not raise, just log warning
+        await migrator.migrate()
+
+    @pytest.mark.asyncio
+    async def test_migrate_success_with_files(
+        self, mock_maria_storage, temp_pvc_dir, sample_hdf5_file
+    ):
+        """Test successful migration with HDF5 files."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_cursor.fetchone = MagicMock(return_value=None)
+        mock_cursor.lastrowid = 1
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage, pvc_folder=str(temp_pvc_dir))
+
+        await migrator.migrate()
+
+        # Verify data was written
+        assert mock_maria_storage.write_data.await_count > 0
+
+
+class TestErrorHandling:
+    """Test error handling and edge cases."""
+
+    def test_discover_hdf5_files_path_is_file(self, mock_maria_storage, temp_pvc_dir):
+        """Test error when PVC path points to a file instead of directory."""
+        file_path = temp_pvc_dir / "not_a_dir.txt"
+        file_path.touch()
+
+        migrator = PVCToDBMigrator(mock_maria_storage, pvc_folder=str(file_path))
+
+        with pytest.raises(NotADirectoryError, match="not a directory"):
+            migrator._discover_hdf5_files()
+
+    @pytest.mark.asyncio
+    async def test_migrate_file_with_deserialization_error(
+        self, mock_maria_storage, temp_pvc_dir
+    ):
+        """Test handling of deserialization errors in byte data."""
+        file_path = temp_pvc_dir / "corrupted_trustyai.hdf5"
+        with h5py.File(file_path, "w") as h5f:
+            # Create corrupted void data that deserialize_rows will fail on
+            bad_data = np.array([b"not-valid-gzip-data-xxxxx"], dtype="V30")
+            dataset = h5f.create_dataset("test_dataset", data=bad_data)
+            dataset.attrs["column_names"] = ["col1"]
+            dataset.attrs["is_bytes"] = True
+
+        migrator = PVCToDBMigrator(mock_maria_storage, pvc_folder=str(temp_pvc_dir))
+
+        with pytest.raises(ValueError, match="Failed to deserialize"):
+            await migrator._migrate_single_file(file_path)
+
+    @pytest.mark.asyncio
+    async def test_migrate_with_file_failure(
+        self, mock_maria_storage, temp_pvc_dir, sample_hdf5_file
+    ):
+        """Test migration continues when individual file fails."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_cursor.fetchone = MagicMock(
+            side_effect=[
+                None,  # migration not completed
+                None,  # first file not migrated
+            ]
+        )
+        mock_cursor.lastrowid = 1
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        # Make write_data fail
+        mock_maria_storage.write_data = AsyncMock(side_effect=Exception("DB error"))
+
+        migrator = PVCToDBMigrator(mock_maria_storage, pvc_folder=str(temp_pvc_dir))
+
+        # Migration should not raise - continues after file error
+        await migrator.migrate()
+
+        # Verify _mark_file_failed was called (via INSERT with error_message)
+        execute_calls = [call[0][0] for call in mock_cursor.execute.call_args_list]
+        assert any("error_message" in call for call in execute_calls)
+
+    @pytest.mark.asyncio
+    async def test_migrate_with_partial_status(self, mock_maria_storage, temp_pvc_dir):
+        """Test migration sets PARTIAL status when some files fail."""
+        # Create two HDF5 files
+        file1 = temp_pvc_dir / "file1_trustyai.hdf5"
+        file2 = temp_pvc_dir / "file2_trustyai.hdf5"
+
+        for file_path in [file1, file2]:
+            with h5py.File(file_path, "w") as h5f:
+                data = np.array([[1, 2], [3, 4]])
+                dataset = h5f.create_dataset("test_dataset", data=data)
+                dataset.attrs["column_names"] = ["col1", "col2"]
+                dataset.attrs["is_bytes"] = False
+
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+
+        # Mock fetchone with smart pattern for validation queries
+        def mock_fetchone(*args, **kwargs):  # noqa: ARG001
+            if mock_cursor.execute.call_args:
+                call_args = mock_cursor.execute.call_args[0]
+                # Validation query returns row count
+                if "trustyai_v2_table_reference" in call_args[0]:
+                    return (2,)  # 2 rows written
+            # For other queries (migration status checks, file status)
+            return None
+
+        mock_cursor.fetchone = MagicMock(side_effect=mock_fetchone)
+        mock_cursor.lastrowid = 1
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        # First file succeeds, second fails
+        mock_maria_storage.write_data = AsyncMock(
+            side_effect=[None, Exception("DB error")]
+        )
+
+        migrator = PVCToDBMigrator(mock_maria_storage, pvc_folder=str(temp_pvc_dir))
+        await migrator.migrate()
+
+        # Verify PARTIAL status was set
+        execute_calls = [
+            (call[0][0], call[0][1] if len(call[0]) > 1 else None)
+            for call in mock_cursor.execute.call_args_list
+        ]
+        partial_update = [
+            call
+            for call in execute_calls
+            if "UPDATE trustyai_migration_status" in call[0]
+            and call[1]
+            and "PARTIAL" in str(call[1])
+        ]
+        assert len(partial_update) > 0
+
+    @pytest.mark.asyncio
+    async def test_migrate_resume_skips_completed_files(
+        self, mock_maria_storage, temp_pvc_dir, sample_hdf5_file
+    ):
+        """Test migration skips files that were already migrated."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_cursor.fetchone = MagicMock(
+            side_effect=[
+                None,  # migration not complete
+                (1,),  # file already migrated (returns count)
+            ]
+        )
+        mock_cursor.lastrowid = 1
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage, pvc_folder=str(temp_pvc_dir))
+        await migrator.migrate()
+
+        # Verify write_data was NOT called (file was skipped)
+        assert mock_maria_storage.write_data.await_count == 0
+
+    def test_mark_methods_with_no_migration_id(self, mock_maria_storage):
+        """Test that mark methods safely return when _migration_id is None."""
+        mock_conn_mgr, mock_cursor = mock_connection_manager()
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        # _migration_id is None by default
+
+        # These should all return early without executing SQL
+        migrator._update_migration_progress(5)
+        migrator._mark_migration_complete()
+        migrator._mark_migration_partial(3, 2)
+        migrator._mark_migration_failed("error")
+        migrator._mark_file_migrated("test.hdf5", "dataset", 10)
+        migrator._mark_file_failed("test.hdf5", "error")
+        result = migrator._is_file_already_migrated("test.hdf5")
+
+        # Verify no SQL was executed
+        assert mock_cursor.execute.call_count == 0
+        assert (
+            result is False
+        )  # _is_file_already_migrated returns False when no migration_id
+
+
+class TestBatchedProcessing:
+    """Test batched data processing for large datasets."""
+
+    @pytest.mark.asyncio
+    async def test_migrate_large_dataset_in_batches(
+        self, mock_maria_storage, temp_pvc_dir
+    ):
+        """Test that large datasets are migrated in configurable batches."""
+        # Create HDF5 file with 2500 rows (will require 3 batches at batch_size=1000)
+        file_path = temp_pvc_dir / "large_dataset_trustyai.hdf5"
+        with h5py.File(file_path, "w") as h5f:
+            # Create large dataset
+            rng = np.random.default_rng()
+            data = rng.random((2500, 3))
+            dataset = h5f.create_dataset("test_dataset", data=data)
+            dataset.attrs["column_names"] = ["col1", "col2", "col3"]
+            dataset.attrs["is_bytes"] = False
+
+        migrator = PVCToDBMigrator(mock_maria_storage, batch_size=1000)
+
+        await migrator._migrate_single_file(file_path)
+
+        # Verify write_data was called 3 times (2500 rows / 1000 batch_size = 3 batches)
+        assert mock_maria_storage.write_data.await_count == 3
+
+        # Verify batch sizes: 1000, 1000, 500
+        call_args = mock_maria_storage.write_data.call_args_list
+        assert len(call_args[0].kwargs["new_rows"]) == 1000  # First batch
+        assert len(call_args[1].kwargs["new_rows"]) == 1000  # Second batch
+        assert len(call_args[2].kwargs["new_rows"]) == 500  # Final batch
+
+    @pytest.mark.asyncio
+    async def test_migrate_small_dataset_single_batch(
+        self, mock_maria_storage, temp_pvc_dir
+    ):
+        """Test that small datasets are migrated in a single batch."""
+        # Create HDF5 file with 500 rows (less than default batch_size=10000)
+        file_path = temp_pvc_dir / "small_dataset_trustyai.hdf5"
+        with h5py.File(file_path, "w") as h5f:
+            rng = np.random.default_rng()
+            data = rng.random((500, 2))
+            dataset = h5f.create_dataset("test_dataset", data=data)
+            dataset.attrs["column_names"] = ["col1", "col2"]
+            dataset.attrs["is_bytes"] = False
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+
+        await migrator._migrate_single_file(file_path)
+
+        # Verify write_data was called once (500 < 10000)
+        assert mock_maria_storage.write_data.await_count == 1
+        assert len(mock_maria_storage.write_data.call_args.kwargs["new_rows"]) == 500
+
+    def test_batch_size_configurable_via_env_var(self, mock_maria_storage, monkeypatch):
+        """Test that batch size can be configured via environment variable."""
+        monkeypatch.setenv("MIGRATION_BATCH_SIZE", "500")
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+
+        assert migrator.batch_size == 500
+
+    def test_batch_size_configurable_via_constructor(self, mock_maria_storage):
+        """Test that batch size can be configured via constructor parameter."""
+        migrator = PVCToDBMigrator(mock_maria_storage, batch_size=2000)
+
+        assert migrator.batch_size == 2000

--- a/tests/service/data/storage/maria/test_timeout_and_metrics.py
+++ b/tests/service/data/storage/maria/test_timeout_and_metrics.py
@@ -1,0 +1,182 @@
+"""Tests for timeout handling and Prometheus metrics in PVC migration."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import h5py
+import numpy as np
+import pytest
+
+from trustyai_service.service.data.storage.maria.pvc_migration import (
+    DEFAULT_TIMEOUT_SECONDS,
+    PVCToDBMigrator,
+    migration_files_failed,
+    migration_files_success,
+    migration_files_total,
+    migration_rows_total,
+)
+
+
+@pytest.fixture
+def mock_maria_storage():
+    """Create a mock MariaDBStorage instance."""
+    storage = MagicMock()
+    storage.connection_manager = MagicMock()
+    storage.write_data = AsyncMock()
+    return storage
+
+
+class TestTimeoutHandling:
+    """Test timeout protection for database writes."""
+
+    @pytest.mark.asyncio
+    async def test_write_with_timeout_success(self, mock_maria_storage):
+        """Test successful write within timeout."""
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        data = np.array([[1, 2, 3]])
+        column_names = ["col1", "col2", "col3"]
+
+        # Should complete without timeout
+        await migrator._write_data_to_maria_with_timeout(
+            "test_dataset", data, column_names, timeout_seconds=5
+        )
+
+        mock_maria_storage.write_data.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_write_with_timeout_exceeded(self, mock_maria_storage):
+        """Test that timeout raises TimeoutError."""
+
+        # Mock write_data to sleep longer than timeout
+        async def slow_write(*_args, **_kwargs):
+            await asyncio.sleep(2)
+
+        mock_maria_storage.write_data = AsyncMock(side_effect=slow_write)
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        data = np.array([[1, 2, 3]])
+        column_names = ["col1", "col2", "col3"]
+
+        # Should raise TimeoutError after 1 second
+        with pytest.raises(TimeoutError, match=r"Database write timeout.*exceeded"):
+            await migrator._write_data_to_maria_with_timeout(
+                "test_dataset", data, column_names, timeout_seconds=1
+            )
+
+    @pytest.mark.asyncio
+    async def test_write_uses_default_timeout(self, mock_maria_storage):
+        """Test that default timeout constant is used when not specified."""
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        data = np.array([[1, 2, 3]])
+        column_names = ["col1", "col2", "col3"]
+
+        # Call without timeout_seconds parameter
+        with patch(
+            "trustyai_service.service.data.storage.maria.pvc_migration.asyncio.timeout"
+        ) as mock_timeout:
+            # Mock the context manager
+            mock_timeout.return_value.__aenter__ = AsyncMock()
+            mock_timeout.return_value.__aexit__ = AsyncMock()
+
+            await migrator._write_data_to_maria_with_timeout(
+                "test_dataset", data, column_names
+            )
+
+            # Verify default timeout was used
+            mock_timeout.assert_called_once_with(DEFAULT_TIMEOUT_SECONDS)
+
+
+class TestPrometheusMetrics:
+    """Test Prometheus metrics incrementation."""
+
+    @pytest.mark.asyncio
+    async def test_metrics_incremented_on_successful_migration(
+        self, mock_maria_storage, tmp_path
+    ):
+        """Test that Prometheus metrics are incremented on successful file migration."""
+        # Create a simple HDF5 file
+        file_path = tmp_path / "test_trustyai.hdf5"
+        with h5py.File(file_path, "w") as h5f:
+            data = np.array([[1, 2, 3], [4, 5, 6]])
+            dataset = h5f.create_dataset("test_dataset", data=data)
+            dataset.attrs["column_names"] = ["col1", "col2", "col3"]
+            dataset.attrs["is_bytes"] = False
+
+        # Mock connection manager with validation support
+        mock_conn_mgr = MagicMock()
+        mock_cursor = MagicMock()
+
+        # Mock fetchone to return row count for validation queries
+        def mock_fetchone(*args, **kwargs):  # noqa: ARG001
+            if mock_cursor.execute.call_args:
+                call_args = mock_cursor.execute.call_args[0]
+                # Validation query returns row count
+                if "trustyai_v2_table_reference" in call_args[0]:
+                    return (2,)  # 2 rows written
+            return None  # Other queries
+
+        mock_cursor.fetchone = MagicMock(side_effect=mock_fetchone)
+        mock_cursor.lastrowid = 1
+        conn_context = MagicMock()
+        conn_context.__enter__ = MagicMock(return_value=(MagicMock(), mock_cursor))
+        conn_context.__exit__ = MagicMock(return_value=None)
+        mock_conn_mgr.__enter__ = MagicMock(return_value=conn_context.__enter__())
+        mock_conn_mgr.__exit__ = MagicMock(return_value=None)
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage, pvc_folder=str(tmp_path))
+
+        # Get initial metric values
+        initial_files_total = migration_files_total._value._value
+        initial_files_success = migration_files_success._value._value
+        initial_rows_total = migration_rows_total._value._value
+
+        # Run migration
+        await migrator.migrate()
+
+        # Verify metrics were incremented
+        assert migration_files_total._value._value == initial_files_total + 1
+        assert migration_files_success._value._value == initial_files_success + 1
+        assert migration_rows_total._value._value == initial_rows_total + 2  # 2 rows
+
+    @pytest.mark.asyncio
+    async def test_metrics_incremented_on_failed_file(
+        self, mock_maria_storage, tmp_path
+    ):
+        """Test that failed file counter is incremented on migration failure."""
+        # Create a corrupted HDF5 file (empty file with .hdf5 extension)
+        file_path = tmp_path / "corrupted_trustyai.hdf5"
+        file_path.write_text("not a valid HDF5 file")
+
+        # Mock connection manager with validation support
+        mock_conn_mgr = MagicMock()
+        mock_cursor = MagicMock()
+
+        # Mock fetchone to return row count for validation queries
+        def mock_fetchone(*args, **kwargs):  # noqa: ARG001
+            if mock_cursor.execute.call_args:
+                call_args = mock_cursor.execute.call_args[0]
+                # Validation query returns row count
+                if "trustyai_v2_table_reference" in call_args[0]:
+                    return (2,)  # 2 rows written
+            return None  # Other queries
+
+        mock_cursor.fetchone = MagicMock(side_effect=mock_fetchone)
+        mock_cursor.lastrowid = 1
+        conn_context = MagicMock()
+        conn_context.__enter__ = MagicMock(return_value=(MagicMock(), mock_cursor))
+        conn_context.__exit__ = MagicMock(return_value=None)
+        mock_conn_mgr.__enter__ = MagicMock(return_value=conn_context.__enter__())
+        mock_conn_mgr.__exit__ = MagicMock(return_value=None)
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage, pvc_folder=str(tmp_path))
+
+        # Get initial metric value
+        initial_files_failed = migration_files_failed._value._value
+
+        # Run migration (should handle error gracefully)
+        await migrator.migrate()
+
+        # Verify failed counter was incremented
+        assert migration_files_failed._value._value == initial_files_failed + 1

--- a/tests/service/data/storage/maria/test_timeout_and_metrics.py
+++ b/tests/service/data/storage/maria/test_timeout_and_metrics.py
@@ -6,14 +6,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import h5py
 import numpy as np
 import pytest
+from prometheus_client import REGISTRY
 
 from trustyai_service.service.data.storage.maria.pvc_migration import (
     DEFAULT_TIMEOUT_SECONDS,
     PVCToDBMigrator,
-    migration_files_failed,
-    migration_files_success,
-    migration_files_total,
-    migration_rows_total,
 )
 
 
@@ -110,6 +107,21 @@ class TestPrometheusMetrics:
         def mock_fetchone(*args, **kwargs):  # noqa: ARG001
             if mock_cursor.execute.call_args:
                 call_args = mock_cursor.execute.call_args[0]
+                # IN_PROGRESS migration check query (in _start_migration_tracking)
+                if (
+                    "SELECT id, total_files FROM trustyai_migration_status"
+                    in call_args[0]
+                ):
+                    return None  # No existing IN_PROGRESS migration
+                # File already migrated check query (in _is_file_already_migrated)
+                if "SELECT id FROM trustyai_file_migration_status" in call_args[0]:
+                    return None  # File not yet migrated
+                # Migration completion check query (in migrate())
+                if (
+                    "SELECT id FROM trustyai_migration_status" in call_args[0]
+                    and "status=?" in call_args[0]
+                ):
+                    return None  # Migration not completed yet
                 # Validation query returns row count
                 if "trustyai_v2_table_reference" in call_args[0]:
                     return (2,)  # 2 rows written
@@ -126,18 +138,34 @@ class TestPrometheusMetrics:
 
         migrator = PVCToDBMigrator(mock_maria_storage, pvc_folder=str(tmp_path))
 
-        # Get initial metric values
-        initial_files_total = migration_files_total._value._value
-        initial_files_success = migration_files_success._value._value
-        initial_rows_total = migration_rows_total._value._value
+        # Get initial metric values using public Prometheus API
+        # Note: Prometheus automatically adds _total suffix to all Counter metrics
+        initial_files_total = (
+            REGISTRY.get_sample_value("trustyai_migration_files_total") or 0
+        )
+        initial_files_success = (
+            REGISTRY.get_sample_value("trustyai_migration_files_success_total") or 0
+        )
+        initial_rows_total = (
+            REGISTRY.get_sample_value("trustyai_migration_rows_total") or 0
+        )
 
         # Run migration
         await migrator.migrate()
 
         # Verify metrics were incremented
-        assert migration_files_total._value._value == initial_files_total + 1
-        assert migration_files_success._value._value == initial_files_success + 1
-        assert migration_rows_total._value._value == initial_rows_total + 2  # 2 rows
+        assert (
+            REGISTRY.get_sample_value("trustyai_migration_files_total")
+            == initial_files_total + 1
+        )
+        assert (
+            REGISTRY.get_sample_value("trustyai_migration_files_success_total")
+            == initial_files_success + 1
+        )
+        assert (
+            REGISTRY.get_sample_value("trustyai_migration_rows_total")
+            == initial_rows_total + 2
+        )  # 2 rows
 
     @pytest.mark.asyncio
     async def test_metrics_incremented_on_failed_file(
@@ -156,6 +184,21 @@ class TestPrometheusMetrics:
         def mock_fetchone(*args, **kwargs):  # noqa: ARG001
             if mock_cursor.execute.call_args:
                 call_args = mock_cursor.execute.call_args[0]
+                # IN_PROGRESS migration check query (in _start_migration_tracking)
+                if (
+                    "SELECT id, total_files FROM trustyai_migration_status"
+                    in call_args[0]
+                ):
+                    return None  # No existing IN_PROGRESS migration
+                # File already migrated check query (in _is_file_already_migrated)
+                if "SELECT id FROM trustyai_file_migration_status" in call_args[0]:
+                    return None  # File not yet migrated
+                # Migration completion check query (in migrate())
+                if (
+                    "SELECT id FROM trustyai_migration_status" in call_args[0]
+                    and "status=?" in call_args[0]
+                ):
+                    return None  # Migration not completed yet
                 # Validation query returns row count
                 if "trustyai_v2_table_reference" in call_args[0]:
                     return (2,)  # 2 rows written
@@ -172,11 +215,17 @@ class TestPrometheusMetrics:
 
         migrator = PVCToDBMigrator(mock_maria_storage, pvc_folder=str(tmp_path))
 
-        # Get initial metric value
-        initial_files_failed = migration_files_failed._value._value
+        # Get initial metric value using public Prometheus API
+        # Note: Prometheus automatically adds _total suffix to all Counter metrics
+        initial_files_failed = (
+            REGISTRY.get_sample_value("trustyai_migration_files_failed_total") or 0
+        )
 
         # Run migration (should handle error gracefully)
         await migrator.migrate()
 
         # Verify failed counter was incremented
-        assert migration_files_failed._value._value == initial_files_failed + 1
+        assert (
+            REGISTRY.get_sample_value("trustyai_migration_files_failed_total")
+            == initial_files_failed + 1
+        )

--- a/tests/service/data/storage/maria/test_validation.py
+++ b/tests/service/data/storage/maria/test_validation.py
@@ -1,0 +1,260 @@
+"""Tests for HDF5 validation in PVC-to-MariaDB migration."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import h5py
+import numpy as np
+import pytest
+
+from trustyai_service.service.data.storage.maria.pvc_migration import PVCToDBMigrator
+
+
+@pytest.fixture
+def mock_maria_storage():
+    """Create a mock MariaDBStorage instance."""
+    storage = MagicMock()
+    storage.connection_manager = MagicMock()
+    storage.write_data = AsyncMock()  # Make write_data async
+    return storage
+
+
+def create_mock_connection_manager(fetchone_return=None):
+    """Create a mock MariaConnectionManager with context manager support."""
+    manager = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone = MagicMock(return_value=fetchone_return)
+
+    # Setup context manager protocol
+    conn_context = MagicMock()
+    conn_context.__enter__ = MagicMock(return_value=(MagicMock(), cursor))
+    conn_context.__exit__ = MagicMock(return_value=None)
+    manager.__enter__ = MagicMock(return_value=conn_context.__enter__())
+    manager.__exit__ = MagicMock(return_value=None)
+
+    return manager, cursor
+
+
+class TestHDF5StructureValidation:
+    """Test HDF5 file structure validation."""
+
+    def test_validate_valid_hdf5_file(self, mock_maria_storage, tmp_path):
+        """Test validation passes for valid HDF5 file."""
+        # Create valid HDF5 file
+        file_path = tmp_path / "valid_trustyai.hdf5"
+        with h5py.File(file_path, "w") as h5f:
+            data = np.array([[1, 2, 3], [4, 5, 6]])
+            dataset = h5f.create_dataset("test_dataset", data=data)
+            dataset.attrs["column_names"] = ["col1", "col2", "col3"]
+            dataset.attrs["is_bytes"] = False
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        is_valid, error_msg = migrator._validate_hdf5_structure(file_path)
+
+        assert is_valid is True
+        assert error_msg == ""
+
+    def test_validate_empty_hdf5_file(self, mock_maria_storage, tmp_path):
+        """Test validation fails for HDF5 file with no datasets."""
+        # Create empty HDF5 file
+        file_path = tmp_path / "empty_trustyai.hdf5"
+        with h5py.File(file_path, "w"):
+            pass  # No datasets
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        is_valid, error_msg = migrator._validate_hdf5_structure(file_path)
+
+        assert is_valid is False
+        assert "no datasets" in error_msg.lower()
+
+    def test_validate_missing_column_names_attribute(
+        self, mock_maria_storage, tmp_path
+    ):
+        """Test validation fails when dataset missing column_names attribute."""
+        # Create HDF5 file without required attribute
+        file_path = tmp_path / "no_columns_trustyai.hdf5"
+        with h5py.File(file_path, "w") as h5f:
+            data = np.array([[1, 2, 3]])
+            h5f.create_dataset("test_dataset", data=data)
+            # Dataset intentionally missing column_names attribute for test
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        is_valid, error_msg = migrator._validate_hdf5_structure(file_path)
+
+        assert is_valid is False
+        assert "column_names" in error_msg
+        assert "test_dataset" in error_msg
+
+    def test_validate_empty_dataset_warns_but_passes(
+        self, mock_maria_storage, tmp_path, caplog
+    ):
+        """Test validation passes but warns for empty dataset."""
+        # Create HDF5 file with empty dataset
+        file_path = tmp_path / "empty_dataset_trustyai.hdf5"
+        with h5py.File(file_path, "w") as h5f:
+            dataset = h5f.create_dataset("empty_dataset", shape=(0, 3))
+            dataset.attrs["column_names"] = ["col1", "col2", "col3"]
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        is_valid, error_msg = migrator._validate_hdf5_structure(file_path)
+
+        # Should pass validation (empty datasets are allowed)
+        assert is_valid is True
+        assert error_msg == ""
+
+        # But should log a warning
+        assert "empty" in caplog.text.lower()
+
+    def test_validate_corrupted_hdf5_file(self, mock_maria_storage, tmp_path):
+        """Test validation fails for corrupted HDF5 file."""
+        # Create corrupted file (not valid HDF5)
+        file_path = tmp_path / "corrupted_trustyai.hdf5"
+        file_path.write_text("This is not a valid HDF5 file")
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        is_valid, error_msg = migrator._validate_hdf5_structure(file_path)
+
+        assert is_valid is False
+        assert "validation error" in error_msg.lower()
+
+    def test_validate_multiple_datasets(self, mock_maria_storage, tmp_path):
+        """Test validation checks all datasets in file."""
+        # Create HDF5 file with multiple datasets
+        file_path = tmp_path / "multi_dataset_trustyai.hdf5"
+        with h5py.File(file_path, "w") as h5f:
+            # First dataset - valid
+            data1 = np.array([[1, 2]])
+            dataset1 = h5f.create_dataset("dataset1", data=data1)
+            dataset1.attrs["column_names"] = ["col1", "col2"]
+
+            # Second dataset - missing column_names
+            data2 = np.array([[3, 4]])
+            h5f.create_dataset("dataset2", data=data2)
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        is_valid, error_msg = migrator._validate_hdf5_structure(file_path)
+
+        # Should fail because dataset2 is missing column_names
+        assert is_valid is False
+        assert "dataset2" in error_msg
+        assert "column_names" in error_msg
+
+
+class TestPostMigrationValidation:
+    """Test post-migration row count validation."""
+
+    @pytest.mark.asyncio
+    async def test_validate_migration_success(self, mock_maria_storage):
+        """Test validation passes when row counts match."""
+        mock_conn_mgr, mock_cursor = create_mock_connection_manager(
+            fetchone_return=(100,)  # 100 rows in DB
+        )
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        result = await migrator._validate_migration("test_dataset", expected_rows=100)
+
+        assert result is True
+        mock_cursor.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_validate_migration_row_count_mismatch(self, mock_maria_storage):
+        """Test validation fails when row counts don't match."""
+        mock_conn_mgr, _mock_cursor = create_mock_connection_manager(
+            fetchone_return=(50,)  # 50 rows in DB
+        )
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        result = await migrator._validate_migration(
+            "test_dataset",
+            expected_rows=100,  # Expected 100
+        )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_validate_migration_dataset_not_found(self, mock_maria_storage):
+        """Test validation fails when dataset not found in MariaDB."""
+        mock_conn_mgr, _mock_cursor = create_mock_connection_manager(
+            fetchone_return=None  # Dataset not found
+        )
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        result = await migrator._validate_migration("missing_dataset", expected_rows=10)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_validate_migration_database_error(self, mock_maria_storage):
+        """Test validation handles database errors gracefully."""
+        mock_conn_mgr = MagicMock()
+        # Simulate database error (e.g., missing table/schema)
+        mock_conn_mgr.__enter__ = MagicMock(
+            side_effect=Exception("Table 'trustyai_v2_table_reference' doesn't exist")
+        )
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+        result = await migrator._validate_migration("test_dataset", expected_rows=100)
+
+        # Should return False instead of raising exception
+        assert result is False
+
+
+class TestMigrationWithValidation:
+    """Test that migration uses validation methods."""
+
+    @pytest.mark.asyncio
+    async def test_migrate_single_file_with_invalid_structure(
+        self, mock_maria_storage, tmp_path
+    ):
+        """Test migration fails early on invalid HDF5 structure."""
+        # Create HDF5 file missing required attributes
+        file_path = tmp_path / "invalid_trustyai.hdf5"
+        with h5py.File(file_path, "w") as h5f:
+            data = np.array([[1, 2, 3]])
+            h5f.create_dataset("test_dataset", data=data)
+            # Missing column_names attribute
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+
+        # Should raise ValueError during pre-migration validation
+        with pytest.raises(ValueError, match="structure validation failed"):
+            await migrator._migrate_single_file(file_path)
+
+        # Database write should never be called
+        mock_maria_storage.write_data.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_migrate_single_file_with_post_validation_failure(
+        self, mock_maria_storage, tmp_path
+    ):
+        """Test migration fails if post-migration validation detects mismatch."""
+        # Create valid HDF5 file
+        file_path = tmp_path / "test_trustyai.hdf5"
+        with h5py.File(file_path, "w") as h5f:
+            data = np.array([[1, 2, 3], [4, 5, 6]])
+            dataset = h5f.create_dataset("test_dataset", data=data)
+            dataset.attrs["column_names"] = ["col1", "col2", "col3"]
+            dataset.attrs["is_bytes"] = False
+
+        # Mock connection manager for validation query
+        mock_conn_mgr = MagicMock()
+        mock_cursor = MagicMock()
+
+        # Simulate row count mismatch (expected 2, but DB says 1)
+        mock_cursor.fetchone = MagicMock(return_value=(1,))
+
+        conn_context = MagicMock()
+        conn_context.__enter__ = MagicMock(return_value=(MagicMock(), mock_cursor))
+        conn_context.__exit__ = MagicMock(return_value=None)
+        mock_conn_mgr.__enter__ = MagicMock(return_value=conn_context.__enter__())
+        mock_conn_mgr.__exit__ = MagicMock(return_value=None)
+        mock_maria_storage.connection_manager = mock_conn_mgr
+
+        migrator = PVCToDBMigrator(mock_maria_storage)
+
+        # Should raise ValueError during post-migration validation
+        with pytest.raises(ValueError, match="Post-migration validation failed"):
+            await migrator._migrate_single_file(file_path)

--- a/uv.lock
+++ b/uv.lock
@@ -2093,7 +2093,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3281,6 +3281,7 @@ wheels = [
 
 [[package]]
 name = "trustyai-service"
+version = "1.0.0rc0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -3344,7 +3345,7 @@ types = [
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=48.0.1,<50" },
-    { name = "fastapi", specifier = ">=0.116,<0.140" },
+    { name = "fastapi", specifier = ">=0.116,<0.138" },
     { name = "fastapi-utils", specifier = ">=0.8,<0.9" },
     { name = "h5py", specifier = ">=3.13,<4" },
     { name = "hypercorn", specifier = ">=0.18,<0.19" },
@@ -3352,7 +3353,7 @@ requires-dist = [
     { name = "javaobj-py3", marker = "extra == 'mariadb'", specifier = ">=0.5,<0.6" },
     { name = "lm-eval", extras = ["api"], marker = "extra == 'eval'", specifier = ">=0.4,<0.5" },
     { name = "mariadb", marker = "extra == 'mariadb'", specifier = ">=1.1,<1.2" },
-    { name = "nltk", marker = "extra == 'eval'", specifier = ">=3.10.0,<4" },
+    { name = "nltk", marker = "extra == 'eval'", specifier = ">=3.9.4,<4" },
     { name = "numpy", specifier = ">=2.0,<3" },
     { name = "pandas", specifier = ">=3.0,<4" },
     { name = "polars", specifier = ">=1.2,<2" },
@@ -3383,7 +3384,7 @@ notebook = [
 test = [
     { name = "aif360", specifier = ">=0.6.1" },
     { name = "hypothesis", specifier = ">=6.151.12" },
-    { name = "pillow", specifier = ">=12.3.0" },
+    { name = "pillow", specifier = ">=12.2.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },


### PR DESCRIPTION
## Summary

- Adopt [Narwhals](https://narwhals-dev.github.io/narwhals/) as a DataFrame compatibility layer, eliminating direct pandas usage from the metric computation path
- DataSource public methods now return `nw.DataFrame`; internal construction stays native pandas
- All metric endpoints, fairness calculators, and the Prometheus scheduler use Narwhals API exclusively
- **Remove Polars as a runtime dependency** — no production or test code imports it
- Removes redundant Polars/Pandas dual test variants from drift endpoints
- Net reduction: +163 / -218 lines (original), +33 / -64 lines (Polars removal)

## What this PR does NOT do

This is **prep work only** — it creates an abstraction boundary but does not yet deliver end-to-end backend flexibility:

- **No user-facing change**: Users interact with the service via REST API and never see or touch DataFrames. The choice of DataFrame backend is entirely internal.
- **No performance improvement**: The storage layer still constructs native pandas DataFrames. Narwhals adds a thin wrapper but doesn't change the computation path.
- **No backend selection mechanism**: A future PR would need to detect the available backend (or accept a configuration flag) and construct native Polars/PyArrow DataFrames in the DataSource layer.
- **Does not remove pandas**: Pandas remains a required runtime dependency (used by storage internals and the consumer ingestion path).

## Why do it now

The value is in **decoupling**: metric and endpoint code no longer imports pandas directly. When a backend swap is needed (e.g., for performance or to reduce the dependency footprint), the change is confined to `data_source.py` — no rewrite of endpoints or metrics required.

## Architecture

```
src/core/               # Pure NumPy (untouched)
src/endpoints/          # Narwhals only (no pandas imports)
src/service/prometheus/ # Narwhals only
src/service/data/datasources/data_source.py  # Wrapping boundary
src/service/data/       # Native pandas (storage internals)
src/endpoints/consumer/ # Native pandas (inbound ingestion path)
```

## Key changes

### Production code (8 files)
| File | Change |
|------|--------|
| `pyproject.toml` | Add `narwhals>=2.0,<3`; **remove `polars`** |
| `data_source.py` | Public methods wrap with `nw.from_native()`; `get_dataframe_with_batch_size` → `_get_native_dataframe`; `DataError` caught internally |
| `metrics_directory.py` | `DataFrame` → `nw.DataFrame` in callable type hints |
| `batch_mean.py` | `.empty` → `.is_empty()` |
| `utils.py` | `.isin()` → `nw.col().is_in()` with `.filter()` |
| `dir.py`, `spd.py` | `[[col]].to_numpy()` → `.select(col).to_numpy()` |
| `prometheus_scheduler.py` | Remove `DataError` handler (now caught at DataSource); all type hints updated |

### Test code (8 files)
- Drift factory and test files: use `pd.DataFrame` wrapped in `nw.from_native()` (no Polars imports)
- Removed 3 duplicate `_polars` test variants (redundant under Narwhals)

## Future work

To add Polars as an optional runtime backend:

1. Add `polars` as an optional dependency: `polars = ["polars>=1.2,<2"]`
2. Add backend detection in `data_source.py` — check if Polars is installed, or accept a config flag
3. Construct native Polars DataFrames instead of pandas when the Polars backend is active
4. All code above DataSource works unchanged (Narwhals handles both)

## Rebase notes

This PR should be rebased on top of PRs #183, #207–#210 before merging:
- **PR #183**: `get_dataframe_by_tag()` will need `nw.from_native()` wrapping (same pattern as other DataSource methods)
- **PRs #207–210**: New tests use `pd.DataFrame` in mocks — must be updated to `nw.from_native(pd.DataFrame(...))` during rebase

## Test plan

- [x] 572 tests pass (`uv run pytest tests/ -k "not maria"`)
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `pyrefly check` clean (src/ and tests/)
- [x] `bandit` clean (0 issues)
- [x] All pre-commit hooks pass
- [x] Zero `import pandas` above the DataSource boundary (verified via grep)
- [x] Zero `import polars` anywhere (verified via grep)
- [x] NaN handling verified safe with pandas backend under Narwhals
- [ ] Rebase on PRs #183, #207–#210 when they merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)