### PR TITLE
fix(tls): honor system crypto policy on port 4443

### DIFF
--- a/src/trustyai_service/main.py
+++ b/src/trustyai_service/main.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from hypercorn.asyncio import serve
-from hypercorn.config import Config
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 # Endpoint routers
@@ -60,6 +59,7 @@ from trustyai_service.middleware.gzip_middleware import GzipRequestMiddleware
 from trustyai_service.service.prometheus.shared_prometheus_scheduler import (
     get_shared_prometheus_scheduler,
 )
+from trustyai_service.service.tls import PolicyAwareConfig
 
 lm_evaluation_harness_router: "APIRouter | None" = None
 try:
@@ -277,7 +277,6 @@ def get_tls_config() -> dict[str, Any] | None:
         return {
             "ssl_keyfile": str(key_path),
             "ssl_certfile": str(cert_path),
-            "ssl_version": 2,  # TLS v1.2+
         }
     logger.info("TLS certificates not found, running in HTTP mode")
     return None
@@ -297,7 +296,7 @@ async def run_server() -> None:
     ssl_port = int(os.getenv("SSL_PORT", "4443"))
 
     # Create hypercorn config
-    config = Config()
+    config = PolicyAwareConfig()
 
     # HTTP for kube-rbac-proxy (plain HTTP on insecure_bind)
     config.insecure_bind = [f"{host_http}:{http_port}"]

--- a/src/trustyai_service/service/tls.py
+++ b/src/trustyai_service/service/tls.py
@@ -1,0 +1,41 @@
+"""TLS configuration that honors the system crypto policy.
+
+Hypercorn hardcodes its cipher list and minimum TLS version, overriding
+the system crypto policy set by ``update-crypto-policies``.  This module
+provides a Config subclass that delegates cipher and version selection to
+the operating system, so the service automatically honors the cluster TLS
+profile (Old, Intermediate, Modern, Custom) and FIPS crypto policy.
+"""
+
+from ssl import OP_NO_COMPRESSION, Purpose, SSLContext, create_default_context
+
+from hypercorn.config import Config
+
+
+class PolicyAwareConfig(Config):
+    """Hypercorn Config that respects the system crypto policy for TLS."""
+
+    def create_ssl_context(self) -> SSLContext | None:
+        """Build an SSL context without overriding ciphers or min version."""
+        if not self.ssl_enabled:
+            return None
+
+        context = create_default_context(Purpose.CLIENT_AUTH)
+        context.options |= OP_NO_COMPRESSION
+        context.set_alpn_protocols(self.alpn_protocols)
+
+        if self.certfile is not None and self.keyfile is not None:
+            context.load_cert_chain(
+                certfile=self.certfile,
+                keyfile=self.keyfile,
+                password=self.keyfile_password,
+            )
+
+        if self.ca_certs is not None:
+            context.load_verify_locations(self.ca_certs)
+        if self.verify_mode is not None:
+            context.verify_mode = self.verify_mode
+        if self.verify_flags is not None:
+            context.verify_flags = self.verify_flags
+
+        return context

--- a/tests/service/test_tls.py
+++ b/tests/service/test_tls.py
@@ -1,0 +1,90 @@
+"""Tests for TLS crypto policy compliance."""
+
+import ssl
+import subprocess
+from pathlib import Path
+
+from trustyai_service.service.tls import PolicyAwareConfig
+
+
+def _generate_self_signed_cert(tmp_path: Path) -> tuple[str, str]:
+    """Generate a self-signed cert and key for testing."""
+    cert_file = tmp_path / "tls.crt"
+    key_file = tmp_path / "tls.key"
+    subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            str(key_file),
+            "-out",
+            str(cert_file),
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/CN=localhost",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return str(cert_file), str(key_file)
+
+
+def _make_tls_config(cert_file: str, key_file: str) -> PolicyAwareConfig:
+    """Create a PolicyAwareConfig with cert and key set."""
+    config = PolicyAwareConfig()
+    config.certfile = cert_file
+    config.keyfile = key_file
+    return config
+
+
+class TestPolicyAwareConfig:
+    """Tests for PolicyAwareConfig SSL context creation."""
+
+    def test_returns_none_when_ssl_disabled(self) -> None:
+        """No SSL context when TLS is not configured."""
+        config = PolicyAwareConfig()
+        assert config.create_ssl_context() is None
+
+    def test_creates_context_with_certs(self, tmp_path: Path) -> None:
+        """SSL context is created when cert and key are provided."""
+        cert_file, key_file = _generate_self_signed_cert(tmp_path)
+        config = _make_tls_config(cert_file, key_file)
+
+        ctx = config.create_ssl_context()
+
+        assert ctx is not None
+        assert isinstance(ctx, ssl.SSLContext)
+
+    def test_does_not_override_ciphers(self, tmp_path: Path) -> None:
+        """Ciphers are not hardcoded — system policy decides."""
+        cert_file, key_file = _generate_self_signed_cert(tmp_path)
+        config = _make_tls_config(cert_file, key_file)
+
+        ctx = config.create_ssl_context()
+        system_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+
+        assert ctx.get_ciphers() == system_ctx.get_ciphers()
+
+    def test_does_not_override_minimum_version(self, tmp_path: Path) -> None:
+        """Minimum TLS version is not hardcoded — system policy decides."""
+        cert_file, key_file = _generate_self_signed_cert(tmp_path)
+        config = _make_tls_config(cert_file, key_file)
+
+        ctx = config.create_ssl_context()
+        system_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+
+        assert ctx.minimum_version == system_ctx.minimum_version
+
+    def test_compression_disabled(self, tmp_path: Path) -> None:
+        """TLS compression is disabled (RFC 7540 Section 9.2.1)."""
+        cert_file, key_file = _generate_self_signed_cert(tmp_path)
+        config = _make_tls_config(cert_file, key_file)
+
+        ctx = config.create_ssl_context()
+
+        assert ctx.options & ssl.OP_NO_COMPRESSION


### PR DESCRIPTION
## Summary

Hypercorn hardcodes its cipher list (`ECDHE+AESGCM`) and minimum TLS version (1.2), overriding the system crypto policy. This means the service ignores the cluster TLS profile (Old, Intermediate, Modern, Custom) and FIPS policy.

Fix by subclassing Hypercorn's `Config` to delegate cipher and version selection to `create_default_context()`, which reads from `/etc/crypto-policies/`. The service now automatically honors:
- OCP TLS profiles (Old, Intermediate, Modern, Custom)
- FIPS crypto policy on FIPS-enabled hosts
- Any future crypto policy changes without code modifications

### Changes
- `src/service/tls.py` — `PolicyAwareConfig` subclass that skips cipher/version hardcoding
- `src/main.py` — use `PolicyAwareConfig` instead of `Config`; remove hardcoded `ssl_version`
- 4 tests: context creation, cipher delegation to system policy, compression disabled

### What stays the same
- TLS compression disabled (RFC 7540 Section 9.2.1)
- Port 8080 HTTP unaffected
- Cert/key loading, CA verification, verify mode all preserved

## Test plan
- [x] `test_returns_none_when_ssl_disabled` — no context without certs
- [x] `test_creates_context_with_certs` — valid context with self-signed cert
- [x] `test_does_not_override_ciphers` — ciphers match system default
- [x] `test_compression_disabled` — OP_NO_COMPRESSION set
- [x] Full test suite — 597 passed
- [x] CI passes

Ref: RHOAIENG-72358

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTPS/TLS handling so secure connections follow the system’s crypto policy.
  * Avoided overriding default cipher suites and minimum TLS version to reduce compatibility issues.
  * Disabled TLS compression for safer encrypted connections.
* **Tests**
  * Added coverage to verify TLS is correctly disabled/enabled and that crypto policy and safety settings are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->