### PR TITLE
fix(ci): add environment approval gate to CI Publish workflow

### DIFF
--- a/.github/workflows/ci-publish.yaml
+++ b/.github/workflows/ci-publish.yaml
@@ -10,6 +10,7 @@ permissions: read-all
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: ci-publish
     if: github.event.workflow_run.conclusion == 'success'
     permissions:
       actions: read


### PR DESCRIPTION
## Summary

Add an `environment: ci-publish` gate to the CI Publish workflow's `publish` job.

## Problem

The `CI Publish` workflow is triggered by `workflow_run`, which grants full access to repository secrets (`QUAY_ROBOT_USERNAME`, `QUAY_ROBOT_SECRET`, `TRUSTYAI_CI_BOT_SSH_KEY`) regardless of what the upstream workflow had access to. [GitHub explicitly warns](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-secrets) about this pattern.

## Fix

Add `environment: ci-publish` to the `publish` job. This restricts secrets access behind an environment protection rule.

## Admin setup required

A repo admin must complete these steps **before merging**:

### 1. Create the environment

**Settings → Environments → New environment** → name it `ci-publish`

### 2. Configure protection rules

- **Required reviewers**: add at least one maintainer (e.g., `trustyai-explainability/reviewers`)
- **Deployment branches**: restrict to `main` only (prevents forks from triggering)

### 3. Move secrets to the environment

Move these 3 secrets from repo-level to the `ci-publish` environment so they are *only* accessible to jobs that pass the environment gate:

| Secret | Used for |
|--------|----------|
| `QUAY_ROBOT_USERNAME` | Quay.io image push authentication |
| `QUAY_ROBOT_SECRET` | Quay.io image push authentication |
| `TRUSTYAI_CI_BOT_SSH_KEY` | Push manifests to opendatahub-io repo |

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release publishing workflow to run under a dedicated environment during publish steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->