### PR TITLE
fix(metrics): replace metric_name str|None override with typed default

### DIFF
--- a/src/trustyai_service/endpoints/metrics/batch_mean.py
+++ b/src/trustyai_service/endpoints/metrics/batch_mean.py
@@ -15,7 +15,7 @@ from http import HTTPStatus
 import numpy as np
 import pandas as pd
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field
 
 from trustyai_service.service.data.datasources.data_source import DataSource
 from trustyai_service.service.data.shared_data_source import get_shared_data_source
@@ -59,19 +59,13 @@ class BatchMeanRequest(BaseMetricRequest):
     model_config = ConfigDict(populate_by_name=True)
 
     model_id: str = Field(alias="modelId")
-    metric_name: str | None = Field(default=None, alias="metricName")
+    metric_name: str = Field(default=METRIC_NAME, alias="metricName")
     request_name: str | None = Field(default=None, alias="requestName")
     batch_size: int = Field(default=DEFAULT_BATCH_SIZE, ge=1, alias="batchSize")
 
     column_name: str = Field(alias="columnName")
     lower_threshold: float | None = Field(default=None, alias="lowerThreshold")
     upper_threshold: float | None = Field(default=None, alias="upperThreshold")
-
-    @model_validator(mode="after")
-    def _set_default_metric_name(self) -> "BatchMeanRequest":
-        if self.metric_name is None:
-            self.metric_name = METRIC_NAME
-        return self
 
     def retrieve_tags(self) -> dict[str, str]:
         """Return Prometheus labels for this metric request."""

--- a/src/trustyai_service/endpoints/metrics/drift/compare_means.py
+++ b/src/trustyai_service/endpoints/metrics/drift/compare_means.py
@@ -6,7 +6,7 @@ from http import HTTPStatus
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field
 
 from trustyai_service.core.metrics.drift.compare_means import (
     DEFAULT_ALPHA,
@@ -62,9 +62,7 @@ class CompareMeansMetricRequest(BaseMetricRequest):
     model_config = ConfigDict(populate_by_name=True)
 
     model_id: str = Field(alias="modelId")
-    metric_name: str | None = Field(
-        default=None, alias="metricName"
-    )  # Will be set by endpoint
+    metric_name: str = Field(default=METRIC_NAME, alias="metricName")
     request_name: str | None = Field(default=None, alias="requestName")
     batch_size: int = Field(default=DEFAULT_BATCH_SIZE, alias="batchSize", gt=0)
 
@@ -74,13 +72,6 @@ class CompareMeansMetricRequest(BaseMetricRequest):
     nan_policy: NanPolicy = Field(default=DEFAULT_NAN_POLICY, alias="nanPolicy")
     reference_tag: str | None = Field(default=None, alias="referenceTag")
     fit_columns: list[str] = Field(default_factory=list, alias="fitColumns")
-
-    @model_validator(mode="after")
-    def _set_default_metric_name(self) -> "CompareMeansMetricRequest":
-        """Automatically set metric_name to default if not provided."""
-        if self.metric_name is None:
-            self.metric_name = METRIC_NAME
-        return self
 
     def retrieve_tags(self) -> dict[str, str]:
         """Retrieve tags for this CompareMeans metric request."""

--- a/src/trustyai_service/endpoints/metrics/drift/jensen_shannon.py
+++ b/src/trustyai_service/endpoints/metrics/drift/jensen_shannon.py
@@ -6,7 +6,7 @@ from http import HTTPStatus
 from typing import Any, Literal, cast
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field
 
 from trustyai_service.core.metrics.drift.jensen_shannon import (
     DEFAULT_BINS,
@@ -58,7 +58,7 @@ class JensenShannonMetricRequest(BaseMetricRequest):
     model_config = ConfigDict(populate_by_name=True)
 
     model_id: str = Field(alias="modelId")
-    metric_name: str | None = Field(default=None, alias="metricName")
+    metric_name: str = Field(default=METRIC_NAME, alias="metricName")
     request_name: str | None = Field(default=None, alias="requestName")
     batch_size: int = Field(default=100, alias="batchSize")
 
@@ -80,13 +80,6 @@ class JensenShannonMetricRequest(BaseMetricRequest):
     )  # Number of bins for histogram method
     reference_tag: str | None = Field(default=None, alias="referenceTag")
     fit_columns: list[str] = Field(default_factory=list, alias="fitColumns")
-
-    @model_validator(mode="after")
-    def _set_default_metric_name(self) -> "JensenShannonMetricRequest":
-        """Automatically set metric_name to default if not provided."""
-        if self.metric_name is None:
-            self.metric_name = METRIC_NAME
-        return self
 
     def retrieve_tags(self) -> dict[str, str]:
         """Retrieve tags for this JensenShannon metric request."""

--- a/src/trustyai_service/endpoints/metrics/drift/kolmogorov_smirnov.py
+++ b/src/trustyai_service/endpoints/metrics/drift/kolmogorov_smirnov.py
@@ -49,9 +49,7 @@ class KSTestMetricRequest(BaseMetricRequest):
     model_config = ConfigDict(populate_by_name=True)
 
     model_id: str = Field(alias="modelId")
-    metric_name: str | None = Field(
-        default=None, alias="metricName"
-    )  # Will be set by endpoint
+    metric_name: str = Field(default=METRIC_NAME, alias="metricName")
     request_name: str | None = Field(default=None, alias="requestName")
     batch_size: int = Field(default=100, alias="batchSize")
 

--- a/tests/endpoints/metrics/test_batch_mean.py
+++ b/tests/endpoints/metrics/test_batch_mean.py
@@ -356,8 +356,8 @@ class TestDeprecatedIdentityEndpoints:
 class TestBatchMeanRequest:
     """Tests for BatchMeanRequest model validation."""
 
-    def test_model_validator_sets_metric_name(self) -> None:
-        """Default metric_name is set to BatchMean by model validator."""
+    def test_default_metric_name(self) -> None:
+        """Default metric_name is set to BatchMean via field default."""
         request = BatchMeanRequest(modelId="test", columnName="col")
         assert request.metric_name == "BatchMean"
 


### PR DESCRIPTION
## Summary

Every metric request subclass overrode `BaseMetricRequest.metric_name: str` with `str | None = Field(default=None)`, then used a `@model_validator` to backfill from a `METRIC_NAME` constant. This caused type checker warnings and unnecessary boilerplate.

Replace with `metric_name: str = Field(default=METRIC_NAME, ...)` — matches the base class type, eliminates the validator, same runtime behavior.

### Changed (4 files, -31 lines)
- `BatchMeanRequest`
- `CompareMeansMetricRequest`
- `JensenShannonMetricRequest`
- `KSTestMetricRequest`

### Unchanged
`GroupMetricRequest` / `GroupDefinitionRequest` — intentionally `str | None` because the metric name is set by the endpoint (SPD/DIR), not a constant.

### API note
Clients that omit `metricName` from requests are unaffected (default applies). Clients that explicitly send `"metricName": null` will now receive a validation error — previously the validator silently replaced null with the default. Sending null explicitly is unusual and unlikely in practice.

## Test plan
- [x] 593 tests pass
- [x] Lint, format, type check clean
- [x] CI passes

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Metric requests now automatically use their corresponding default metric names when none is provided.
  * Request validation is more consistent across batch mean and drift metric endpoints.
* **Tests**
  * Updated validation coverage to confirm default metric names are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->