### PR TITLE
fix(fairness): enforce single-prediction invariant in IndividualConsistency

### DIFF
--- a/src/trustyai_service/core/metrics/fairness/individual/individual_consistency.py
+++ b/src/trustyai_service/core/metrics/fairness/individual/individual_consistency.py
@@ -33,6 +33,12 @@ class IndividualConsistency:
             if len(prediction_outputs) == 0:
                 msg = "Model output cannot be empty."
                 raise ValueError(msg)
+            if len(prediction_outputs) != 1:
+                msg = (
+                    f"Expected 1 prediction per sample, got {len(prediction_outputs)}. "
+                    "The model must return exactly one prediction for a single input."
+                )
+                raise ValueError(msg)
             prediction_output = prediction_outputs[0]
             # Handle both scalar and array predictions
             output_width = int(np.size(prediction_output))

--- a/tests/core/metrics/test_fairness.py
+++ b/tests/core/metrics/test_fairness.py
@@ -556,3 +556,22 @@ def test_individual_consistency_imperfect() -> None:
     )
 
     assert consistency == pytest.approx(cs_score, abs=0.2)
+
+
+def test_individual_consistency_rejects_multi_prediction_model() -> None:
+    """Model returning multiple predictions per sample is rejected."""
+    X_sample = get_processed_data(sample_size=5)
+
+    class MultiPredictionModel:
+        """Model that incorrectly returns multiple predictions per sample."""
+
+        def predict(self, _x: np.ndarray) -> list[list[int]]:
+            """Return 2 predictions for any input."""
+            return [[1], [2]]
+
+    with pytest.raises(ValueError, match="Expected 1 prediction per sample"):
+        IndividualConsistency.calculate(
+            proximity_function=get_k_neighbors_function(3),
+            samples=X_sample,
+            model=MultiPredictionModel(),
+        )


### PR DESCRIPTION
## Summary

The refactoring in PR #122 changed the IndividualConsistency denominator from `len(samples)` to `len(prediction_outputs)`. These are equivalent only if `model.predict(single_sample)` returns exactly 1 prediction per sample.

Add an explicit guard that enforces this invariant — if a model returns multiple predictions for a single sample, raise `ValueError` instead of silently computing incorrect consistency.

### Changes
- `individual_consistency.py` — add `len(prediction_outputs) != 1` check with descriptive error
- `test_fairness.py` — add `test_individual_consistency_rejects_multi_prediction_model`

## Test plan
- [x] All 4 individual consistency tests pass
- [x] Full suite: 594 passed
- [x] Lint, type check clean
- [x] CI passes

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)