### PR TITLE
test(fairness): add DIR edge case tests for zero favorable outcomes

### DIFF
--- a/tests/core/metrics/test_fairness.py
+++ b/tests/core/metrics/test_fairness.py
@@ -317,6 +317,32 @@ class TestDisparateImpactRatio:
             f"unprivileged group. Actual score {score}"
         )
 
+    def test_dir_zero_favorable_privileged(self) -> None:
+        """DIR returns inf when privileged group has zero favorable outcomes."""
+        privileged = np.array([[0, 0], [1, 0]])
+        unprivileged = np.array([[0, 1], [1, 1]])
+
+        score = DisparateImpactRatio.calculate(
+            privileged=privileged,
+            unprivileged=unprivileged,
+            favorable_outputs=np.array([1]),
+        )
+
+        assert score == np.inf
+
+    def test_dir_zero_favorable_both_groups(self) -> None:
+        """DIR returns nan when both groups have zero favorable outcomes."""
+        privileged = np.array([[0, 0], [1, 0]])
+        unprivileged = np.array([[0, 0], [1, 0]])
+
+        score = DisparateImpactRatio.calculate(
+            privileged=privileged,
+            unprivileged=unprivileged,
+            favorable_outputs=np.array([1]),
+        )
+
+        assert np.isnan(score)
+
     def test_dir_equal_favorable_rates(self) -> None:
         """Test to check that the result of DIR calculation is 1.0 when favorable outcome rates are equal between groups."""
         df = pd.DataFrame(generate_data())


### PR DESCRIPTION
## Summary

Add explicit tests for DIR boundary conditions that the property-based test currently skips via `assume()`:

| Test | Scenario | Expected |
|------|----------|----------|
| `test_dir_zero_favorable_privileged` | Privileged group has no favorable outcomes | `np.inf` (x/0) |
| `test_dir_zero_favorable_both_groups` | Both groups have no favorable outcomes | `np.nan` (0/0) |
| `test_dir_zero_favorable_unprivileged` | *(already existed)* Unprivileged has no favorable | `0.0` (0/x) |

## Test plan
- [x] All 3 DIR zero-favorable tests pass
- [x] Full suite: 595 passed
- [x] CI passes

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)