### PR TITLE
fix(schema): infer DataType from KServe datatype instead of hardcoding STRING

### DIFF
--- a/src/trustyai_service/endpoints/consumer/__init__.py
+++ b/src/trustyai_service/endpoints/consumer/__init__.py
@@ -6,6 +6,8 @@ from typing import Any, Literal
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from trustyai_service.service.payloads.values.data_type import DataType
+
 PartialKind = Literal["request", "response"]
 
 
@@ -52,6 +54,22 @@ K_SERVE_NUMPY_DTYPES = {
     KServeDataType.FP16: np.float16,
     KServeDataType.FP32: np.float32,
     KServeDataType.FP64: np.float64,
+}
+
+KSERVE_TO_DATATYPE: dict[KServeDataType, DataType] = {
+    KServeDataType.BOOL: DataType.BOOL,
+    KServeDataType.INT8: DataType.INT32,
+    KServeDataType.INT16: DataType.INT32,
+    KServeDataType.INT32: DataType.INT32,
+    KServeDataType.INT64: DataType.INT64,
+    KServeDataType.UINT8: DataType.INT32,
+    KServeDataType.UINT16: DataType.INT32,
+    KServeDataType.UINT32: DataType.INT64,
+    KServeDataType.UINT64: DataType.INT64,
+    KServeDataType.FP16: DataType.FLOAT,
+    KServeDataType.FP32: DataType.FLOAT,
+    KServeDataType.FP64: DataType.DOUBLE,
+    KServeDataType.BYTES: DataType.STRING,
 }
 
 

--- a/src/trustyai_service/endpoints/consumer/consumer_endpoint.py
+++ b/src/trustyai_service/endpoints/consumer/consumer_endpoint.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Header, HTTPException
 from numpy import ndarray
 
 from trustyai_service.endpoints.consumer import (
+    KSERVE_TO_DATATYPE,
     InferencePartialPayload,
     KServeData,
     KServeInferenceRequest,
@@ -21,8 +22,6 @@ from trustyai_service.endpoints.consumer import (
 )
 from trustyai_service.exceptions import ReconciliationError
 from trustyai_service.service.data.datasources.data_source import DataSource
-
-# Import local dependencies
 from trustyai_service.service.data.model_data import ModelData
 from trustyai_service.service.data.modelmesh_parser import (
     ModelMeshPayloadParser,
@@ -30,6 +29,7 @@ from trustyai_service.service.data.modelmesh_parser import (
 )
 from trustyai_service.service.data.shared_data_source import get_shared_data_source
 from trustyai_service.service.data.storage import get_global_storage_interface
+from trustyai_service.service.payloads.values.data_type import DataType
 from trustyai_service.service.utils import list_utils
 
 # Define constants locally to avoid import issues
@@ -319,8 +319,10 @@ async def reconcile_kserve(
     :param output_payload: KServe inference response containing outputs
     :param tag: Optional tag to associate with the data
     """
-    input_array, input_names = process_payload(input_payload, lambda p: p.inputs)
-    output_array, output_names = process_payload(
+    input_array, input_names, input_types = process_payload(
+        input_payload, lambda p: p.inputs
+    )
+    output_array, output_names, output_types = process_payload(
         output_payload, lambda p: p.outputs, input_array.shape[0]
     )
 
@@ -342,6 +344,16 @@ async def reconcile_kserve(
         model_id=output_payload.model_name,
         tags=tags,
         id_=input_payload.id,
+    )
+
+    storage_interface = get_global_storage_interface()
+    input_dataset = output_payload.model_name + INPUT_SUFFIX
+    output_dataset = output_payload.model_name + OUTPUT_SUFFIX
+    await storage_interface.set_column_types(
+        input_dataset, [t.value for t in input_types]
+    )
+    await storage_interface.set_column_types(
+        output_dataset, [t.value for t in output_types]
     )
 
 
@@ -387,13 +399,13 @@ def process_payload(
     payload: KServeInferenceRequest | KServeInferenceResponse,
     get_data: Callable,
     enforced_first_shape: int | None = None,
-) -> tuple[np.ndarray, list[str]]:
-    """Process a KServe payload and extract data array and column names.
+) -> tuple[np.ndarray, list[str], list[DataType]]:
+    """Process a KServe payload and extract data array, column names, and column types.
 
     :param payload: KServe request or response payload
     :param get_data: Function to extract inputs or outputs from payload
     :param enforced_first_shape: Expected number of rows (for validation)
-    :return: Tuple of (data array, column names list)
+    :return: Tuple of (data array, column names list, column types list)
     :raises ReconciliationError: If shapes don't match expectations
     """
     if (
@@ -403,10 +415,14 @@ def process_payload(
         shapes = set()
         shape_tuples = []
         column_names = []
+        column_types = []
         for kserve_data in get_data(payload):
             data.append(kserve_data.data)
             shapes.add(tuple(kserve_data.shape))
             column_names.append(kserve_data.name)
+            column_types.append(
+                KSERVE_TO_DATATYPE.get(kserve_data.datatype, DataType.UNKNOWN)
+            )
             shape_tuples.append((kserve_data.name, kserve_data.shape))
         if len(shapes) == 1:
             row_count = next(iter(shapes))[0]
@@ -415,8 +431,8 @@ def process_payload(
                     payload.id, enforced_first_shape, row_count
                 )
             if list_utils.contains_non_numeric(data):
-                return np.array(data, dtype="O").T, column_names
-            return np.array(data).T, column_names
+                return np.array(data, dtype="O").T, column_names, column_types
+            return np.array(data).T, column_names, column_types
         reconcile_mismatching_shape_error(
             shape_tuples,
             "input" if enforced_first_shape is None else "output",
@@ -438,9 +454,11 @@ def process_payload(
             ]
         else:
             column_names = [kserve_data.name]
+        mapped_type = KSERVE_TO_DATATYPE.get(kserve_data.datatype, DataType.UNKNOWN)
+        column_types = [mapped_type] * len(column_names)
         if list_utils.contains_non_numeric(kserve_data.data):
-            return np.array(kserve_data.data, dtype="O"), column_names
-        return np.array(kserve_data.data), column_names
+            return np.array(kserve_data.data, dtype="O"), column_names, column_types
+        return np.array(kserve_data.data), column_names, column_types
 
 
 @router.post("/")

--- a/src/trustyai_service/service/data/datasources/data_source.py
+++ b/src/trustyai_service/service/data/datasources/data_source.py
@@ -7,8 +7,10 @@ import pandas as pd
 
 from trustyai_service.service.constants import (
     GROUND_TRUTH_SUFFIX,
+    INPUT_SUFFIX,
     INTERNAL_DATA_FILENAME,
     METADATA_FILENAME,
+    OUTPUT_SUFFIX,
     UNLABELED_TAG,
 )
 from trustyai_service.service.data.exceptions import (
@@ -26,6 +28,17 @@ from trustyai_service.service.payloads.service.schema_item import SchemaItem
 from trustyai_service.service.payloads.values.data_type import DataType
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _safe_datatype(types: list[str] | None, index: int) -> DataType:
+    """Look up a DataType from a stored types list, defaulting to UNKNOWN."""
+    if types is None or index >= len(types):
+        return DataType.UNKNOWN
+    try:
+        return DataType(types[index])
+    except ValueError:
+        return DataType.UNKNOWN
+
 
 # Array dimensionality constants for NumPy shape checks
 ARRAY_DIM_2D = 2
@@ -198,15 +211,20 @@ class DataSource:
             input_rows, output_rows, metadata_rows = await model_data.row_counts()
             input_names, output_names, metadata_names = await model_data.column_names()
 
+            input_dataset = model_id + INPUT_SUFFIX
+            input_types = await self.storage_interface.get_column_types(input_dataset)
             input_items = {}
             for i, name in enumerate(input_names):
-                # Default to STRING type - in a real implementation this would be determined from the data
-                input_items[name] = SchemaItem(DataType.STRING, name, i)
+                dtype = _safe_datatype(input_types, i)
+                input_items[name] = SchemaItem(dtype, name, i)
             input_schema = Schema(input_items)
 
+            output_dataset = model_id + OUTPUT_SUFFIX
+            output_types = await self.storage_interface.get_column_types(output_dataset)
             output_items = {}
             for i, name in enumerate(output_names):
-                output_items[name] = SchemaItem(DataType.STRING, name, i)
+                dtype = _safe_datatype(output_types, i)
+                output_items[name] = SchemaItem(dtype, name, i)
             output_schema = Schema(output_items)
 
             metadata = StorageMetadata(

--- a/src/trustyai_service/service/data/storage/pvc.py
+++ b/src/trustyai_service/service/data/storage/pvc.py
@@ -44,6 +44,7 @@ from .storage_interface import StorageInterface
 logger = logging.getLogger(__name__)
 COLUMN_NAMES_ATTRIBUTE = "column_names"
 COLUMN_ALIAS_ATTRIBUTE = "column_aliases"
+COLUMN_TYPES_ATTRIBUTE = "column_types"
 BYTES_ATTRIBUTE = "is_bytes"
 
 PARTIAL_INPUT_NAME = PROTECTED_DATASET_SUFFIX + PARTIAL_PAYLOAD_DATASET_NAME + "_inputs"
@@ -441,6 +442,35 @@ class PVCStorage(StorageInterface):
                         "but dataset was not found in the database.",
                         allocated_dataset_name,
                     )
+
+    async def set_column_types(
+        self, dataset_name: str, column_types: list[str]
+    ) -> None:
+        """Store column types as an HDF5 attribute."""
+        allocated_dataset_name = self.allocate_valid_dataset_name(dataset_name)
+        async with self.get_lock(allocated_dataset_name):
+            try:
+                with H5PYContext(self, dataset_name, "a") as db:
+                    if allocated_dataset_name in db:
+                        dataset = db[allocated_dataset_name]
+                        if COLUMN_TYPES_ATTRIBUTE not in dataset.attrs:
+                            dataset.attrs[COLUMN_TYPES_ATTRIBUTE] = column_types
+            except MissingH5PYDataError:
+                pass
+
+    async def get_column_types(self, dataset_name: str) -> list[str] | None:
+        """Read column types from HDF5 attribute. Returns None for old data."""
+        allocated_dataset_name = self.allocate_valid_dataset_name(dataset_name)
+        async with self.get_lock(allocated_dataset_name):
+            try:
+                with H5PYContext(self, dataset_name, "r") as db:
+                    if allocated_dataset_name in db:
+                        dataset = db[allocated_dataset_name]
+                        if COLUMN_TYPES_ATTRIBUTE in dataset.attrs:
+                            return list(dataset.attrs[COLUMN_TYPES_ATTRIBUTE])
+            except MissingH5PYDataError:
+                pass
+            return None
 
     async def get_known_models(self) -> list[str]:
         """Get a list of all model IDs that have inference data stored."""

--- a/src/trustyai_service/service/data/storage/storage_interface.py
+++ b/src/trustyai_service/service/data/storage/storage_interface.py
@@ -61,6 +61,17 @@ class StorageInterface(ABC):
     async def clear_name_mapping(self, dataset_name: str) -> None:
         """Clear all column name aliases from a dataset."""
 
+    async def set_column_types(
+        self, dataset_name: str, column_types: list[str]
+    ) -> None:
+        """Store column type information. Override in backends that support it."""
+        _ = dataset_name, column_types
+
+    async def get_column_types(self, dataset_name: str) -> list[str] | None:
+        """Read column type information. Returns None if backend doesn't support it."""
+        _ = dataset_name
+        return None
+
     @abstractmethod
     async def get_known_models(self) -> list[str]:
         """Get a list of all model IDs that have inference data stored."""

--- a/tests/endpoints/consumer/test_kserve_datatype_mapping.py
+++ b/tests/endpoints/consumer/test_kserve_datatype_mapping.py
@@ -1,5 +1,8 @@
 """Tests for KServe datatype → internal DataType mapping."""
 
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
 from trustyai_service.endpoints.consumer import (
@@ -9,8 +12,14 @@ from trustyai_service.endpoints.consumer import (
     KServeInferenceRequest,
     KServeInferenceResponse,
 )
-from trustyai_service.endpoints.consumer.consumer_endpoint import process_payload
-from trustyai_service.service.data.datasources.data_source import _safe_datatype
+from trustyai_service.endpoints.consumer.consumer_endpoint import (
+    process_payload,
+)
+from trustyai_service.service.data.datasources.data_source import (
+    DataSource,
+    _safe_datatype,
+)
+from trustyai_service.service.data.storage.pvc import PVCStorage
 from trustyai_service.service.payloads.values.data_type import DataType
 
 
@@ -192,3 +201,90 @@ class TestSafeDataTypeFallback:
         assert _safe_datatype(["DOUBLE", "INT32", "FLOAT"], 0) == DataType.DOUBLE
         assert _safe_datatype(["DOUBLE", "INT32", "FLOAT"], 1) == DataType.INT32
         assert _safe_datatype(["DOUBLE", "INT32", "FLOAT"], 2) == DataType.FLOAT
+
+
+_STORAGE_PATCH = "trustyai_service.service.data.model_data.get_global_storage_interface"
+
+
+class TestDataTypeRoundTrip:
+    """Verify data types survive the full round-trip through PVC storage and get_metadata().
+
+    Tests the chain: set_column_types() → HDF5 attribute → get_column_types() → get_metadata() schema.
+    """
+
+    @pytest.fixture
+    def pvc_storage(self, tmp_path: Path) -> PVCStorage:
+        """Create a temporary PVC storage backend."""
+        return PVCStorage(str(tmp_path), data_file="test.hdf5")
+
+    @pytest.mark.asyncio
+    async def test_fp64_roundtrip(self, pvc_storage: PVCStorage) -> None:
+        """FP64 inputs + FP32 output persist as DOUBLE/FLOAT in get_metadata() schema."""
+        await pvc_storage.write_data(
+            "m_inputs", [[25.0, 50000.0], [30.0, 60000.0]], ["age", "income"]
+        )
+        await pvc_storage.write_data("m_outputs", [[0.95], [0.42]], ["score"])
+        await pvc_storage.write_data("m_metadata", [["t"], ["t"]], ["tags"])
+        await pvc_storage.set_column_types("m_inputs", ["DOUBLE", "DOUBLE"])
+        await pvc_storage.set_column_types("m_outputs", ["FLOAT"])
+
+        with patch(_STORAGE_PATCH, return_value=pvc_storage):
+            data_source = DataSource()
+            data_source.storage_interface = pvc_storage
+            metadata = await data_source.get_metadata("m")
+
+        assert metadata.input_schema.items["age"].type == DataType.DOUBLE
+        assert metadata.input_schema.items["income"].type == DataType.DOUBLE
+        assert metadata.output_schema.items["score"].type == DataType.FLOAT
+
+    @pytest.mark.asyncio
+    async def test_mixed_types_roundtrip(self, pvc_storage: PVCStorage) -> None:
+        """INT32 + BOOL inputs persist with correct types, not STRING."""
+        await pvc_storage.write_data(
+            "mx_inputs", [[10, True], [20, False]], ["count", "flag"]
+        )
+        await pvc_storage.write_data("mx_outputs", [[1], [0]], ["pred"])
+        await pvc_storage.write_data("mx_metadata", [["t"], ["t"]], ["tags"])
+        await pvc_storage.set_column_types("mx_inputs", ["INT32", "BOOL"])
+        await pvc_storage.set_column_types("mx_outputs", ["INT64"])
+
+        with patch(_STORAGE_PATCH, return_value=pvc_storage):
+            data_source = DataSource()
+            data_source.storage_interface = pvc_storage
+            metadata = await data_source.get_metadata("mx")
+
+        assert metadata.input_schema.items["count"].type == DataType.INT32
+        assert metadata.input_schema.items["flag"].type == DataType.BOOL
+        assert metadata.output_schema.items["pred"].type == DataType.INT64
+
+    @pytest.mark.asyncio
+    async def test_old_data_without_types_returns_unknown(
+        self, pvc_storage: PVCStorage
+    ) -> None:
+        """Data written without set_column_types falls back to UNKNOWN, not STRING."""
+        await pvc_storage.write_data("legacy_inputs", [[1.0, 2.0]], ["f1", "f2"])
+        await pvc_storage.write_data("legacy_outputs", [[0.5]], ["out"])
+        await pvc_storage.write_data("legacy_metadata", [["tag"]], ["tags"])
+
+        with patch(_STORAGE_PATCH, return_value=pvc_storage):
+            data_source = DataSource()
+            data_source.storage_interface = pvc_storage
+            metadata = await data_source.get_metadata("legacy")
+
+        assert metadata.input_schema.items["f1"].type == DataType.UNKNOWN
+        assert metadata.output_schema.items["out"].type == DataType.UNKNOWN
+
+    def test_process_payload_types_match_storage_values(self) -> None:
+        """Types from process_payload() are valid DataType.value strings for set_column_types()."""
+        request = KServeInferenceRequest(
+            id="chain-test",
+            inputs=[
+                KServeData(name="x", shape=[1], datatype="FP64", data=[1.0]),
+                KServeData(name="y", shape=[1], datatype="INT32", data=[42]),
+            ],
+        )
+        _, _, types = process_payload(request, lambda p: p.inputs)
+
+        for dt in types:
+            assert isinstance(dt, DataType)
+            assert dt.value == DataType(dt.value).value

--- a/tests/endpoints/consumer/test_kserve_datatype_mapping.py
+++ b/tests/endpoints/consumer/test_kserve_datatype_mapping.py
@@ -1,0 +1,194 @@
+"""Tests for KServe datatype → internal DataType mapping."""
+
+import pytest
+
+from trustyai_service.endpoints.consumer import (
+    KSERVE_TO_DATATYPE,
+    KServeData,
+    KServeDataType,
+    KServeInferenceRequest,
+    KServeInferenceResponse,
+)
+from trustyai_service.endpoints.consumer.consumer_endpoint import process_payload
+from trustyai_service.service.data.datasources.data_source import _safe_datatype
+from trustyai_service.service.payloads.values.data_type import DataType
+
+
+class TestKServeToDataTypeMapping:
+    """Verify the KSERVE_TO_DATATYPE mapping covers all KServe types."""
+
+    def test_all_kserve_types_mapped(self) -> None:
+        """Every KServeDataType has a mapping entry."""
+        for kserve_type in KServeDataType:
+            assert kserve_type in KSERVE_TO_DATATYPE, (
+                f"{kserve_type} missing from KSERVE_TO_DATATYPE"
+            )
+
+    @pytest.mark.parametrize(
+        ("kserve_type", "expected"),
+        [
+            (KServeDataType.BOOL, DataType.BOOL),
+            (KServeDataType.INT8, DataType.INT32),
+            (KServeDataType.INT16, DataType.INT32),
+            (KServeDataType.INT32, DataType.INT32),
+            (KServeDataType.INT64, DataType.INT64),
+            (KServeDataType.UINT8, DataType.INT32),
+            (KServeDataType.UINT16, DataType.INT32),
+            (KServeDataType.UINT32, DataType.INT64),
+            (KServeDataType.UINT64, DataType.INT64),
+            (KServeDataType.FP16, DataType.FLOAT),
+            (KServeDataType.FP32, DataType.FLOAT),
+            (KServeDataType.FP64, DataType.DOUBLE),
+            (KServeDataType.BYTES, DataType.STRING),
+        ],
+    )
+    def test_specific_mappings(
+        self, kserve_type: KServeDataType, expected: DataType
+    ) -> None:
+        """Each KServe type maps to the correct internal DataType."""
+        assert KSERVE_TO_DATATYPE[kserve_type] == expected
+
+
+class TestProcessPayloadTypes:
+    """Verify process_payload returns correct column types."""
+
+    def test_single_tensor_fp64_returns_double(self) -> None:
+        """Single FP64 tensor with shape [3,2] → 2 DOUBLE columns."""
+        request = KServeInferenceRequest(
+            id="test-1",
+            inputs=[
+                KServeData(
+                    name="features",
+                    shape=[3, 2],
+                    datatype="FP64",
+                    data=[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+                ),
+            ],
+        )
+
+        _, names, types = process_payload(request, lambda p: p.inputs)
+
+        assert names == ["features-0", "features-1"]
+        assert types == [DataType.DOUBLE, DataType.DOUBLE]
+
+    def test_single_tensor_int32_returns_int32(self) -> None:
+        """Single INT32 tensor with shape [2,3] → 3 INT32 columns."""
+        request = KServeInferenceRequest(
+            id="test-2",
+            inputs=[
+                KServeData(
+                    name="input",
+                    shape=[2, 3],
+                    datatype="INT32",
+                    data=[[1, 2, 3], [4, 5, 6]],
+                ),
+            ],
+        )
+
+        _, names, types = process_payload(request, lambda p: p.inputs)
+
+        assert len(names) == 3  # noqa: PLR2004
+        assert types == [DataType.INT32, DataType.INT32, DataType.INT32]
+
+    def test_single_tensor_1d_returns_single_type(self) -> None:
+        """Single FP32 tensor with shape [3] → 1 FLOAT column."""
+        response = KServeInferenceResponse(
+            model_name="test-model",
+            id="test-3",
+            outputs=[
+                KServeData(
+                    name="predict",
+                    shape=[3],
+                    datatype="FP32",
+                    data=[0.1, 0.2, 0.3],
+                ),
+            ],
+        )
+
+        _, names, types = process_payload(response, lambda p: p.outputs)
+
+        assert names == ["predict"]
+        assert types == [DataType.FLOAT]
+
+    def test_multi_tensor_different_types(self) -> None:
+        """Multiple tensors with different types → per-tensor mapping."""
+        request = KServeInferenceRequest(
+            id="test-4",
+            inputs=[
+                KServeData(
+                    name="age",
+                    shape=[2],
+                    datatype="FP64",
+                    data=[25.0, 30.0],
+                ),
+                KServeData(
+                    name="score",
+                    shape=[2],
+                    datatype="INT32",
+                    data=[100, 200],
+                ),
+            ],
+        )
+
+        _, names, types = process_payload(request, lambda p: p.inputs)
+
+        assert names == ["age", "score"]
+        assert types == [DataType.DOUBLE, DataType.INT32]
+
+    def test_bool_type(self) -> None:
+        """BOOL tensor maps to DataType.BOOL."""
+        request = KServeInferenceRequest(
+            id="test-5",
+            inputs=[
+                KServeData(
+                    name="flag",
+                    shape=[2],
+                    datatype="BOOL",
+                    data=[True, False],
+                ),
+            ],
+        )
+
+        _, _, types = process_payload(request, lambda p: p.inputs)
+
+        assert types == [DataType.BOOL]
+
+    def test_bytes_type(self) -> None:
+        """BYTES tensor maps to DataType.STRING."""
+        request = KServeInferenceRequest(
+            id="test-6",
+            inputs=[
+                KServeData(
+                    name="text",
+                    shape=[2],
+                    datatype="BYTES",
+                    data=["hello", "world"],
+                ),
+            ],
+        )
+
+        _, _, types = process_payload(request, lambda p: p.inputs)
+
+        assert types == [DataType.STRING]
+
+
+class TestSafeDataTypeFallback:
+    """Verify _safe_datatype handles missing or corrupted type info."""
+
+    def test_none_types_returns_unknown(self) -> None:
+        """None types list falls back to UNKNOWN."""
+        assert _safe_datatype(None, 0) == DataType.UNKNOWN
+
+    def test_index_out_of_range_returns_unknown(self) -> None:
+        """Index beyond types list falls back to UNKNOWN."""
+        assert _safe_datatype(["DOUBLE"], 5) == DataType.UNKNOWN
+
+    def test_invalid_type_string_returns_unknown(self) -> None:
+        """Corrupted type string falls back to UNKNOWN."""
+        assert _safe_datatype(["INVALID_TYPE"], 0) == DataType.UNKNOWN
+
+    def test_valid_type_string_returns_correct_type(self) -> None:
+        """Valid stored type string returns correct DataType."""
+        assert _safe_datatype(["DOUBLE", "INT32", "FLOAT"], 0) == DataType.DOUBLE
+        assert _safe_datatype(["DOUBLE", "INT32", "FLOAT"], 1) == DataType.INT32
+        assert _safe_datatype(["DOUBLE", "INT32", "FLOAT"], 2) == DataType.FLOAT


### PR DESCRIPTION
## Summary

Map KServe payload datatypes (FP64, FP32, INT32, etc.) to internal DataType enum (DOUBLE, FLOAT, INT32, etc.) during ingestion and persist to storage. Previously all columns were hardcoded as STRING, breaking numerical drift metrics that require numeric types.

Fixes #247

## Changes

| File | Change |
|------|--------|
| `src/endpoints/consumer/__init__.py` | Add `KSERVE_TO_DATATYPE` mapping (13 KServe types → 9 internal types) |
| `src/endpoints/consumer/consumer_endpoint.py` | Return column types from `process_payload()`; persist types after reconciliation |
| `src/service/data/storage/storage_interface.py` | Add non-abstract `set/get_column_types` with safe defaults |
| `src/service/data/storage/pvc.py` | Implement type persistence as HDF5 dataset attribute |
| `src/service/data/datasources/data_source.py` | Read stored types in `get_metadata()` instead of hardcoding STRING |

## Backward compatibility

- Old data without type attributes → falls back to `DataType.UNKNOWN` (not crash)
- Non-abstract defaults on `StorageInterface` → MariaDB and DBStorage implementations unaffected
- `write_reconciled_data` signature unchanged → no impact on other callers

## Test plan

- [x] 599 tests pass (575 existing + 24 new)
- [x] Mapping covers all 13 KServeDataType values
- [x] Single-tensor FP64 → DOUBLE, INT32 → INT32, BOOL → BOOL, BYTES → STRING
- [x] Multi-tensor with mixed types → per-tensor mapping
- [x] `_safe_datatype` handles None, out-of-range, and invalid strings → UNKNOWN
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `pyrefly check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preserving and reading per-column data types alongside stored datasets.
  * Improved payload handling so input and output column types are inferred more accurately, including multi-column expansions.

* **Bug Fixes**
  * Metadata now reflects stored column types instead of defaulting all fields to strings.
  * Older or incomplete type data is handled safely with a fallback value.

* **Tests**
  * Added coverage for datatype mapping, payload inference, and type fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->